### PR TITLE
Enhance first run experience by updating README with installation and authentication steps for opencode, improving LSP debug export logic, and validating queries in request handling.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,24 @@ is for people who dont have "skill issues."  This is meant to streamline the req
 3. Still very alpha, could have severe problems
 
 ## How to use
-**you must have opencode installed and setup**
+
+### Prerequisites
+**You must have opencode installed and authenticated**
+
+1. Install opencode:
+   ```bash
+   curl -fsSL https://opencode.ai/install | bash
+   ```
+
+2. Authenticate with your preferred provider:
+   ```bash
+   opencode auth login
+   ```
+   Select your provider (Anthropic, GitHub Copilot, OpenAI, etc.) and follow the prompts.
+
+By default, 99 uses whatever model you configured in opencode. To use a specific model, add the `model` option to your setup (see configuration below).
+
+### Configuration
 
 Add the following configuration to your neovim config
 
@@ -30,6 +47,10 @@ I make the assumption you are using Lazy
 					path = "/tmp/" .. basename .. ".99.debug",
 					print_on_error = true,
 				},
+
+                --- Optional: override the model (defaults to opencode's configured model)
+                --- Examples: "github-copilot/gpt-4o", "anthropic/claude-sonnet-4-5", "opencode/gpt-5-nano"
+                --- model = "github-copilot/gpt-4o",
 
                 --- WARNING: if you change cwd then this is likely broken
                 --- ill likely fix this in a later change

--- a/lua/99/editor/lsp.lua
+++ b/lua/99/editor/lsp.lua
@@ -1117,9 +1117,16 @@ end
 -- The SymbolKind enum is also exported for filtering operations.
 --------------------------------------------------------------------------------
 
-Lsp.get_module_exports(0, "99.editor.lsp", function(exports)
-    Lsp.print_module_exports(exports)
-end)
+-- Only run debug export if LSP is actually attached
+vim.defer_fn(function()
+    local bufnr = vim.api.nvim_get_current_buf()
+    local clients = vim.lsp.get_clients({ bufnr = bufnr })
+    if #clients > 0 then
+        Lsp.get_module_exports(bufnr, "99.editor.lsp", function(exports)
+            Lsp.print_module_exports(exports)
+        end)
+    end
+end, 200)
 
 return {
     Lsp = Lsp,

--- a/lua/99/init.lua
+++ b/lua/99/init.lua
@@ -23,7 +23,7 @@ local Range = require("99.geo").Range
 --- @return _99.StateProps
 local function create_99_state()
     return {
-        model = "opencode/claude-opus-4-5",
+        model = "",  -- Empty string uses opencode's default model configuration
         md_files = {},
         prompts = require("99.prompt-settings"),
         ai_stdout_rows = 3,

--- a/lua/99/request/init.lua
+++ b/lua/99/request/init.lua
@@ -46,7 +46,20 @@ function OpenCodeProvider:make_request(query, request, observer)
         observer.on_complete(status, text)
     end)
 
-    local command = { "opencode", "run", "-m", request.context.model, query }
+    -- Validate query before building command
+    if not query or query == "" then
+        logger:error("make_request", "query is empty or nil")
+        once_complete("failed", "No query provided")
+        return
+    end
+
+    local command = { "opencode", "run" }
+    if request.context.model and request.context.model ~= "" then
+        table.insert(command, "-m")
+        table.insert(command, request.context.model)
+    end
+    table.insert(command, query)
+
     logger:debug("make_request", "command", command)
     vim.system(
         command,


### PR DESCRIPTION

  ## Summary
  Fixes three critical issues that prevent the plugin from working on first install:

  1. **LSP debug code crashes on startup** - The plugin tried to call LSP methods before LSP was attached, causing `Error: No LSP client attached to buffer` on every startup
  2. **Non-existent default model** - Hardcoded `opencode/claude-opus-4-5` doesn't exist, causing immediate failures
  3. **Missing tmp directory** - Plugin expects `tmp/` directory for temporary files but it wasn't in the repo

  ## Changes

  ### 1. Fix LSP Debug Export (`lua/99/editor/lsp.lua`)
  - Wrap debug export in `vim.defer_fn()` with LSP client check
  - Only runs if LSP is actually attached to the buffer
  - Prevents startup errors

  ### 2. Smart Model Selection (`lua/99/init.lua` + `lua/99/request/init.lua`)
  - Default to empty string instead of non-existent model
  - Only pass `-m` flag to opencode if model is explicitly set
  - Uses opencode's default model configuration (from `opencode auth login`)
  - Users can still override by setting `model = "provider/model"` in setup

  ### 3. Add Query Validation (`lua/99/request/init.lua`)
  - Validate query exists before building command
  - Fail gracefully with error message if query is missing

  ### 4. Add tmp Directory
  - Create `tmp/.gitignore` so directory exists in repo
  - Plugin writes temporary files here during operation

  ### 5. Update README (`README.md`)
  - Add installation instructions for opencode
  - Document authentication requirement
  - Explain model configuration with examples

  ## Testing
  - [x] Tested with fresh install
  - [x] Verified LSP error is gone
  - [x] Confirmed plugin uses opencode's default model
  - [x] Tested model override in setup still works

  ## Why These Changes Matter
  Without these fixes, new users get errors immediately and the plugin doesn't work. This PR makes the first-run experience actually functional.
