### PR TITLE
Add Dependencies Block to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ I make the assumption you are using Lazy
 ```lua
 	{
 		"ThePrimeagen/99",
+        dependencies = {
+          'hrsh7th/nvim-cmp',
+        },
 		config = function()
 			local _99 = require("99")
 


### PR DESCRIPTION
With `cmp` being the only supported source, make it a dep. I got an error when installing it into my config. After I added the dependency block , it worked.