### PR TITLE
Fix FileSink Logger

### DIFF
--- a/lua/99/logger/logger.lua
+++ b/lua/99/logger/logger.lua
@@ -69,7 +69,8 @@ function FileSink:new(path)
   -- Ensure the directory is already there (*thanks Windows*)
   vim.fn.mkdir(vim.fn.fnamemodify(path, ":h"), "p")
 
-  local fd, err = vim.uv.fs_open(path, "w", 0)
+  -- 420 decimal == 644 octal (rw-r--r--)
+  local fd, err = vim.uv.fs_open(path, "w", 420)
   if not fd then
     error("unable to file sink: " .. err)
   end


### PR DESCRIPTION
The block with the error used to throw a message when booting neovim saying `bad argument #2 to 'error' (number expected, got string)`. This fixes that.

I added directory creation logic because it's required for Windows.

The permissions for the log files were throwing errors in Windows and are probably not right for log files in Linux. The file permissions used to be `rwxr-xr-x`, but logs don't need executable.