### PR TITLE
Add custom provider support

### DIFF
--- a/lua/99/init.lua
+++ b/lua/99/init.lua
@@ -96,6 +96,7 @@ end
 --- @field model string?
 --- @field md_files string[]?
 --- @field provider _99.Providers.BaseProvider?
+--- @field custom_provider_cmd string?
 --- @field debug_log_prefix string?
 --- @field display_errors? boolean
 --- @field auto_add_skills? boolean
@@ -441,7 +442,14 @@ end
 function _99.setup(opts)
   opts = opts or {}
   _99_state = _99_State.new()
-  _99_state.provider_override = opts.provider
+
+  if opts.custom_provider_cmd then
+    assert(type(opts.custom_provider_cmd) == "string", "opts.custom_provider_cmd is not a string")
+    _99_state.provider_override = Providers.CustomProvider.new(opts.custom_provider_cmd)
+  else
+    _99_state.provider_override = opts.provider
+  end
+
   _99_state.completion = opts.completion
     or {
       source = nil,
@@ -469,7 +477,7 @@ function _99.setup(opts)
     assert(type(opts.model) == "string", "opts.model is not a string")
     _99_state.model = opts.model
   else
-    local provider = opts.provider or Providers.OpenCodeProvider
+    local provider = _99_state.provider_override or Providers.OpenCodeProvider
     if provider._get_default_model then
       _99_state.model = provider._get_default_model()
     end

--- a/lua/99/test/providers_spec.lua
+++ b/lua/99/test/providers_spec.lua
@@ -61,6 +61,19 @@ describe("providers", function()
     end)
   end)
 
+  describe("CustomProvider", function()
+    it("builds correct command", function()
+      local provider = Providers.CustomProvider.new("/path/to/script.sh")
+      local cmd = Providers.CustomProvider._build_command(provider, "test query", {})
+      eq({ "/path/to/script.sh", "test query" }, cmd)
+    end)
+
+    it("returns correct provider name", function()
+      local provider = Providers.CustomProvider.new("/path/to/script.sh")
+      eq("CustomProvider", Providers.CustomProvider._get_provider_name(provider))
+    end)
+  end)
+
   describe("provider integration", function()
     it("can be set as provider override", function()
       local _99 = require("99")
@@ -112,6 +125,25 @@ describe("providers", function()
       })
       local state = _99.__get_state()
       eq("custom-model", state.model)
+    end)
+
+    it("sets CustomProvider when custom_provider_cmd is specified", function()
+      local _99 = require("99")
+
+      _99.setup({ custom_provider_cmd = "/usr/bin/my-ai" })
+      local state = _99.__get_state()
+      eq("CustomProvider", state.provider_override:_get_provider_name())
+    end)
+
+    it("custom_provider_cmd takes priority over provider parameter", function()
+      local _99 = require("99")
+
+      _99.setup({
+        custom_provider_cmd = "/usr/bin/my-ai",
+        provider = Providers.ClaudeCodeProvider,
+      })
+      local state = _99.__get_state()
+      eq("CustomProvider", state.provider_override:_get_provider_name())
     end)
   end)
 


### PR DESCRIPTION
Allows users to integrate any AI service via custom bash script using the custom_provider_cmd option.