### PR TITLE
Option to add extra args to providers

### DIFF
--- a/lua/99/init.lua
+++ b/lua/99/init.lua
@@ -54,6 +54,7 @@ end
 --- @field in_flight_options? _99.StatusWindow.Opts
 --- @field md_files? string[]
 --- @field provider? _99.Providers.BaseProvider
+--- @field provider_extra_args? string[]
 --- @field display_errors? boolean
 --- @field auto_add_skills? boolean
 --- @field completion? _99.Completion
@@ -436,6 +437,13 @@ function _99.setup(opts)
     if provider._get_default_model then
       _99_state.model = provider._get_default_model()
     end
+  end
+
+  if opts.provider_extra_args then
+    assert(
+      type(opts.provider_extra_args) == "table",
+      "opts.provider_extra_args must be a table"
+    )
   end
 
   if opts.md_files then

--- a/lua/99/providers.lua
+++ b/lua/99/providers.lua
@@ -73,9 +73,7 @@ function BaseProvider:make_request(query, context, observer)
   local command = self:_build_command(query, context)
   local extra_args = context._99 and context._99.provider_extra_args or {}
   if #extra_args > 0 then
-    local query_arg = table.remove(command)
     vim.list_extend(command, extra_args)
-    table.insert(command, query_arg)
   end
   logger:debug("make_request", "command", command)
 

--- a/lua/99/providers.lua
+++ b/lua/99/providers.lua
@@ -71,6 +71,12 @@ function BaseProvider:make_request(query, context, observer)
   )
 
   local command = self:_build_command(query, context)
+  local extra_args = context._99 and context._99.provider_extra_args or {}
+  if #extra_args > 0 then
+    local query_arg = table.remove(command)
+    vim.list_extend(command, extra_args)
+    table.insert(command, query_arg)
+  end
   logger:debug("make_request", "command", command)
 
   local proc = vim.system(

--- a/lua/99/state.lua
+++ b/lua/99/state.lua
@@ -30,6 +30,7 @@ end
 --- @field ai_stdout_rows number
 --- @field display_errors boolean
 --- @field provider_override _99.Providers.BaseProvider?
+--- @field provider_extra_args string[]
 --- @field rules _99.Agents.Rules
 --- @field tracking _99.State.Tracking
 --- @field __tmp_dir string | nil
@@ -73,6 +74,7 @@ function State.new(opts)
   local _99_state = setmetatable(props, State) --[[@as _99.State]]
 
   _99_state.provider_override = opts.provider
+  _99_state.provider_extra_args = opts.provider_extra_args or {}
   _99_state.completion = opts.completion or default_completion()
   _99_state.completion.custom_rules = _99_state.completion.custom_rules or {}
   _99_state.completion.files = _99_state.completion.files or {}

--- a/lua/99/test/providers_spec.lua
+++ b/lua/99/test/providers_spec.lua
@@ -152,6 +152,24 @@ describe("providers", function()
     end)
   end)
 
+  describe("provider_extra_args", function()
+    it("stores provider_extra_args on state", function()
+      local _99 = require("99")
+      _99.setup({
+        provider_extra_args = { "--no-session-persistence" },
+      })
+      local state = _99.__get_state()
+      eq({ "--no-session-persistence" }, state.provider_extra_args)
+    end)
+
+    it("defaults provider_extra_args to empty table", function()
+      local _99 = require("99")
+      _99.setup({})
+      local state = _99.__get_state()
+      eq({}, state.provider_extra_args)
+    end)
+  end)
+
   describe("BaseProvider", function()
     it("all providers have make_request", function()
       eq("function", type(Providers.OpenCodeProvider.make_request))


### PR DESCRIPTION
option to add extra args to prompt.

In my case i don't want a session per code change in clause so i add  "--no-session-persistence" 

 `vim.iter` is only available For Neovim 0.10+. don't know what version comp you looking for 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes how provider subprocess commands are constructed and allows arbitrary flags to be appended, which could break some provider CLIs depending on argument ordering.
> 
> **Overview**
> Adds a new `setup()` option, `provider_extra_args`, which is stored on `_99` state and validated as a list.
> 
> Updates `BaseProvider:make_request` to append these extra args to the generated provider command before spawning the subprocess, and adds tests covering state storage/defaulting for this option.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f2b428104851dae8bcfad73f2da604a07c0678ec. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->