### PR TITLE
feat: add JavaScript language support

### DIFF
--- a/lua/99/init.lua
+++ b/lua/99/init.lua
@@ -76,7 +76,7 @@ local function create_99_state()
     md_files = {},
     prompts = require("99.prompt-settings"),
     ai_stdout_rows = 3,
-    languages = { "lua", "go", "java", "elixir", "cpp", "ruby" },
+    languages = { "lua", "go", "java", "elixir", "cpp", "ruby", "javascript" },
     display_errors = false,
     provider_override = nil,
     auto_add_skills = false,

--- a/lua/99/language/javascript.lua
+++ b/lua/99/language/javascript.lua
@@ -1,0 +1,11 @@
+local M = {}
+
+M.names = {}
+
+--- @param item_name string
+--- @return string
+function M.log_item(item_name)
+  return string.format("console.log(%s)", item_name)
+end
+
+return M

--- a/lua/99/test/fill_in_function.javascript_spec.lua
+++ b/lua/99/test/fill_in_function.javascript_spec.lua
@@ -1,0 +1,93 @@
+---@module "plenary.busted"
+
+-- luacheck: globals describe it assert
+local _99 = require("99")
+local test_utils = require("99.test.test_utils")
+local Levels = require("99.logger.level")
+local eq = assert.are.same
+
+--- @param content string[]
+--- @param row number
+--- @param col number
+--- @param lang string?
+--- @return _99.test.Provider, number
+local function setup(content, row, col, lang)
+  assert(lang, "lang must be provided")
+  local provider = test_utils.TestProvider.new()
+  _99.setup({
+    provider = provider,
+    logger = {
+      error_cache_level = Levels.ERROR,
+      type = "print",
+    },
+  })
+
+  local buffer = test_utils.create_file(content, lang, row, col)
+  return provider, buffer
+end
+
+--- @param buffer number
+--- @return string[]
+local function read(buffer)
+  return vim.api.nvim_buf_get_lines(buffer, 0, -1, false)
+end
+
+describe("fill_in_function", function()
+  it("fill in javascript function declaration", function()
+    local content = {
+      "",
+      "function fibonacci(n) {",
+      "}",
+    }
+    local provider, buffer = setup(content, 2, 5, "javascript")
+    local state = _99.__get_state()
+
+    _99.fill_in_function()
+
+    eq(1, state:active_request_count())
+    eq(content, read(buffer))
+
+    provider:resolve(
+      "success",
+      "function fibonacci(n) {\n  if (n <= 1) return n;\n  return fibonacci(n - 1) + fibonacci(n - 2);\n}"
+    )
+    test_utils.next_frame()
+
+    local expected_state = {
+      "",
+      "function fibonacci(n) {",
+      "  if (n <= 1) return n;",
+      "  return fibonacci(n - 1) + fibonacci(n - 2);",
+      "}",
+    }
+    eq(expected_state, read(buffer))
+    eq(0, state:active_request_count())
+  end)
+
+  it("fill in javascript arrow function", function()
+    local content = {
+      "",
+      "const add = (a, b) => {",
+      "}",
+    }
+    local provider, buffer = setup(content, 2, 15, "javascript")
+    local state = _99.__get_state()
+
+    _99.fill_in_function()
+
+    eq(1, state:active_request_count())
+    eq(content, read(buffer))
+
+    provider:resolve("success", "(a, b) => {\n  return a + b;\n}")
+    test_utils.next_frame()
+
+    local expected_state = {
+      "",
+      "const add = (a, b) => {",
+      "  return a + b;",
+      "}",
+    }
+    eq(expected_state, read(buffer))
+    eq(0, state:active_request_count())
+  end)
+end)

--- a/queries/javascript/99-function.scm
+++ b/queries/javascript/99-function.scm
@@ -1,0 +1,24 @@
+(function_declaration) @context.function
+(function_expression) @context.function
+(arrow_function) @context.function
+(method_definition) @context.function
+(generator_function) @context.function
+(generator_function_declaration) @context.function
+
+(function_declaration
+  body: (statement_block) @context.body)
+
+(function_expression
+  body: (statement_block) @context.body)
+
+(arrow_function
+  body: (statement_block) @context.body)
+
+(method_definition
+  body: (statement_block) @context.body)
+
+(generator_function
+  body: (statement_block) @context.body)
+
+(generator_function_declaration
+  body: (statement_block) @context.body)


### PR DESCRIPTION
## Summary
- Add JavaScript language support for fill_in_function
- Supports function declarations, expressions, arrow functions, methods, and generators
- Uses `console.log()` for log_item

## Files
- `queries/javascript/99-function.scm` — treesitter function detection
- `lua/99/language/javascript.lua` — language config (log_item)
- `lua/99/test/fill_in_function.javascript_spec.lua` — tests
- `lua/99/init.lua` — register language

## Testing
All checks pass: `make pr_ready` (luacheck, stylua, plenary tests)

---
Co-authored with AI (Claude), human-reviewed.