### PR TITLE
feat: add Bash language support

### DIFF
--- a/lua/99/init.lua
+++ b/lua/99/init.lua
@@ -76,7 +76,7 @@ local function create_99_state()
     md_files = {},
     prompts = require("99.prompt-settings"),
     ai_stdout_rows = 3,
-    languages = { "lua", "go", "java", "elixir", "cpp", "ruby" },
+    languages = { "lua", "go", "java", "elixir", "cpp", "ruby", "bash" },
     display_errors = false,
     provider_override = nil,
     auto_add_skills = false,

--- a/lua/99/language/bash.lua
+++ b/lua/99/language/bash.lua
@@ -1,0 +1,11 @@
+local M = {}
+
+M.names = {}
+
+--- @param item_name string
+--- @return string
+function M.log_item(item_name)
+  return string.format('echo "$%s"', item_name)
+end
+
+return M

--- a/lua/99/request-context.lua
+++ b/lua/99/request-context.lua
@@ -29,6 +29,8 @@ function RequestContext.from_current_buffer(_99, xid)
 
   if file_type == "typescriptreact" then
     file_type = "typescript"
+  elseif file_type == "sh" then
+    file_type = "bash"
   end
 
   local mds = {}

--- a/lua/99/test/fill_in_function.bash_spec.lua
+++ b/lua/99/test/fill_in_function.bash_spec.lua
@@ -1,0 +1,103 @@
+---@module "plenary.busted"
+
+-- luacheck: globals describe it assert
+local _99 = require("99")
+local test_utils = require("99.test.test_utils")
+local Levels = require("99.logger.level")
+local eq = assert.are.same
+
+--- @param content string[]
+--- @param row number
+--- @param col number
+--- @param lang string?
+--- @return _99.test.Provider, number
+local function setup(content, row, col, lang)
+  assert(lang, "lang must be provided")
+  local provider = test_utils.TestProvider.new()
+  _99.setup({
+    provider = provider,
+    logger = {
+      error_cache_level = Levels.ERROR,
+      type = "print",
+    },
+  })
+
+  local buffer = test_utils.create_file(content, lang, row, col)
+  return provider, buffer
+end
+
+--- @param buffer number
+--- @return string[]
+local function read(buffer)
+  return vim.api.nvim_buf_get_lines(buffer, 0, -1, false)
+end
+
+describe("fill_in_function", function()
+  it("fill in bash function", function()
+    local content = {
+      "",
+      "fibonacci() {",
+      "}",
+    }
+    local provider, buffer = setup(content, 2, 5, "bash")
+    local state = _99.__get_state()
+
+    _99.fill_in_function()
+
+    eq(1, state:active_request_count())
+    eq(content, read(buffer))
+
+    local response = "fibonacci() {\n"
+      .. "    local n=$1\n"
+      .. '    if [ "$n" -le 1 ]; then\n'
+      .. '        echo "$n"\n'
+      .. "        return\n"
+      .. "    fi\n"
+      .. "    echo $((n))\n"
+      .. "}"
+    provider:resolve("success", response)
+    test_utils.next_frame()
+
+    local expected_state = {
+      "",
+      "fibonacci() {",
+      "    local n=$1",
+      '    if [ "$n" -le 1 ]; then',
+      '        echo "$n"',
+      "        return",
+      "    fi",
+      "    echo $((n))",
+      "}",
+    }
+    eq(expected_state, read(buffer))
+    eq(0, state:active_request_count())
+  end)
+
+  it("fill in bash function with function keyword", function()
+    local content = {
+      "",
+      "function greet() {",
+      "    # say hello",
+      "}",
+    }
+    local provider, buffer = setup(content, 2, 5, "bash")
+    local state = _99.__get_state()
+
+    _99.fill_in_function()
+
+    eq(1, state:active_request_count())
+    eq(content, read(buffer))
+
+    provider:resolve("success", 'function greet() {\n    echo "Hello, $1!"\n}')
+    test_utils.next_frame()
+
+    local expected_state = {
+      "",
+      "function greet() {",
+      '    echo "Hello, $1!"',
+      "}",
+    }
+    eq(expected_state, read(buffer))
+    eq(0, state:active_request_count())
+  end)
+end)

--- a/queries/bash/99-function.scm
+++ b/queries/bash/99-function.scm
@@ -1,0 +1,4 @@
+(function_definition) @context.function
+
+(function_definition
+  body: (compound_statement) @context.body)


### PR DESCRIPTION
## Summary
- Add Bash language support for fill_in_function
- Supports function definitions with compound_statement bodies
- Uses `echo "$var"` for log_item
- Adds `sh` filetype mapping to `bash`

## Files
- `queries/bash/99-function.scm` — treesitter function detection
- `lua/99/language/bash.lua` — language config (log_item)
- `lua/99/test/fill_in_function.bash_spec.lua` — tests
- `lua/99/init.lua` — register language
- `lua/99/request-context.lua` — filetype mapping (sh → bash)

## Testing
All checks pass: `make pr_ready` (luacheck, stylua, plenary tests)

---
Co-authored with AI (Claude), human-reviewed.