### PR TITLE
feat: add Haskell language support

### DIFF
--- a/lua/99/init.lua
+++ b/lua/99/init.lua
@@ -76,7 +76,7 @@ local function create_99_state()
     md_files = {},
     prompts = require("99.prompt-settings"),
     ai_stdout_rows = 3,
-    languages = { "lua", "go", "java", "elixir", "cpp", "ruby" },
+    languages = { "lua", "go", "java", "elixir", "cpp", "ruby", "haskell" },
     display_errors = false,
     provider_override = nil,
     auto_add_skills = false,

--- a/lua/99/language/haskell.lua
+++ b/lua/99/language/haskell.lua
@@ -1,0 +1,11 @@
+local M = {}
+
+M.names = {}
+
+--- @param item_name string
+--- @return string
+function M.log_item(item_name)
+  return string.format("print %s", item_name)
+end
+
+return M

--- a/lua/99/test/fill_in_function.haskell_spec.lua
+++ b/lua/99/test/fill_in_function.haskell_spec.lua
@@ -1,0 +1,64 @@
+---@module "plenary.busted"
+
+-- luacheck: globals describe it assert
+local _99 = require("99")
+local test_utils = require("99.test.test_utils")
+local Levels = require("99.logger.level")
+local eq = assert.are.same
+
+--- @param content string[]
+--- @param row number
+--- @param col number
+--- @param lang string?
+--- @return _99.test.Provider, number
+local function setup(content, row, col, lang)
+  assert(lang, "lang must be provided")
+  local provider = test_utils.TestProvider.new()
+  _99.setup({
+    provider = provider,
+    logger = {
+      error_cache_level = Levels.ERROR,
+      type = "print",
+    },
+  })
+
+  local buffer = test_utils.create_file(content, lang, row, col)
+  return provider, buffer
+end
+
+--- @param buffer number
+--- @return string[]
+local function read(buffer)
+  return vim.api.nvim_buf_get_lines(buffer, 0, -1, false)
+end
+
+describe("fill_in_function", function()
+  it("fill in haskell function", function()
+    local content = {
+      "",
+      "fibonacci n = undefined",
+    }
+    local provider, buffer = setup(content, 2, 5, "haskell")
+    local state = _99.__get_state()
+
+    _99.fill_in_function()
+
+    eq(1, state:active_request_count())
+    eq(content, read(buffer))
+
+    provider:resolve(
+      "success",
+      "fibonacci 0 = 0\nfibonacci 1 = 1\nfibonacci n = fibonacci (n - 1) + fibonacci (n - 2)"
+    )
+    test_utils.next_frame()
+
+    local expected_state = {
+      "",
+      "fibonacci 0 = 0",
+      "fibonacci 1 = 1",
+      "fibonacci n = fibonacci (n - 1) + fibonacci (n - 2)",
+    }
+    eq(expected_state, read(buffer))
+    eq(0, state:active_request_count())
+  end)
+end)

--- a/queries/haskell/99-function.scm
+++ b/queries/haskell/99-function.scm
@@ -1,0 +1,4 @@
+(function) @context.function
+
+(function
+  match: (match) @context.body)


### PR DESCRIPTION
## Summary
- Add Haskell language support for fill_in_function
- Supports top-level function definitions with match bodies
- Uses `print` for log_item

## Files
- `queries/haskell/99-function.scm` — treesitter function detection
- `lua/99/language/haskell.lua` — language config (log_item)
- `lua/99/test/fill_in_function.haskell_spec.lua` — tests
- `lua/99/init.lua` — register language

## Testing
All checks pass: `make pr_ready` (luacheck, stylua, plenary tests)

---
Co-authored with AI (Claude), human-reviewed.