### PR TITLE
feat: add PowerShell language support

### DIFF
--- a/lua/99/init.lua
+++ b/lua/99/init.lua
@@ -76,7 +76,7 @@ local function create_99_state()
     md_files = {},
     prompts = require("99.prompt-settings"),
     ai_stdout_rows = 3,
-    languages = { "lua", "go", "java", "elixir", "cpp", "ruby" },
+    languages = { "lua", "go", "java", "elixir", "cpp", "ruby", "powershell" },
     display_errors = false,
     provider_override = nil,
     auto_add_skills = false,

--- a/lua/99/language/powershell.lua
+++ b/lua/99/language/powershell.lua
@@ -1,0 +1,11 @@
+local M = {}
+
+M.names = {}
+
+--- @param item_name string
+--- @return string
+function M.log_item(item_name)
+  return string.format("Write-Output $%s", item_name)
+end
+
+return M

--- a/lua/99/request-context.lua
+++ b/lua/99/request-context.lua
@@ -29,6 +29,8 @@ function RequestContext.from_current_buffer(_99, xid)
 
   if file_type == "typescriptreact" then
     file_type = "typescript"
+  elseif file_type == "ps1" then
+    file_type = "powershell"
   end
 
   local mds = {}

--- a/lua/99/test/fill_in_function.powershell_spec.lua
+++ b/lua/99/test/fill_in_function.powershell_spec.lua
@@ -1,0 +1,70 @@
+---@module "plenary.busted"
+
+-- luacheck: globals describe it assert
+local _99 = require("99")
+local test_utils = require("99.test.test_utils")
+local Levels = require("99.logger.level")
+local eq = assert.are.same
+
+--- @param content string[]
+--- @param row number
+--- @param col number
+--- @param lang string?
+--- @return _99.test.Provider, number
+local function setup(content, row, col, lang)
+  assert(lang, "lang must be provided")
+  local provider = test_utils.TestProvider.new()
+  _99.setup({
+    provider = provider,
+    logger = {
+      error_cache_level = Levels.ERROR,
+      type = "print",
+    },
+  })
+
+  local buffer = test_utils.create_file(content, lang, row, col)
+  return provider, buffer
+end
+
+--- @param buffer number
+--- @return string[]
+local function read(buffer)
+  return vim.api.nvim_buf_get_lines(buffer, 0, -1, false)
+end
+
+describe("fill_in_function", function()
+  it("fill in powershell function", function()
+    local content = {
+      "",
+      "function Get-Fibonacci {",
+      "    param([int]$n)",
+      "}",
+    }
+    local provider, buffer = setup(content, 2, 5, "powershell")
+    local state = _99.__get_state()
+
+    _99.fill_in_function()
+
+    eq(1, state:active_request_count())
+    eq(content, read(buffer))
+
+    local response = "function Get-Fibonacci {\n"
+      .. "    param([int]$n)\n"
+      .. "    if ($n -le 1) { return $n }\n"
+      .. "    return (Get-Fibonacci ($n - 1)) + (Get-Fibonacci ($n - 2))\n"
+      .. "}"
+    provider:resolve("success", response)
+    test_utils.next_frame()
+
+    local expected_state = {
+      "",
+      "function Get-Fibonacci {",
+      "    param([int]$n)",
+      "    if ($n -le 1) { return $n }",
+      "    return (Get-Fibonacci ($n - 1)) + (Get-Fibonacci ($n - 2))",
+      "}",
+    }
+    eq(expected_state, read(buffer))
+    eq(0, state:active_request_count())
+  end)
+end)

--- a/queries/powershell/99-function.scm
+++ b/queries/powershell/99-function.scm
@@ -1,0 +1,4 @@
+(function_statement) @context.function
+
+(function_statement
+  (script_block) @context.body)


### PR DESCRIPTION
Add PowerShell language support for fill_in_function.

Includes `ps1` → `powershell` filetype mapping in `request-context.lua` since neovim reports `.ps1` files as filetype `ps1` while tree-sitter uses the `powershell` parser.

Co-authored with AI (Claude), human-reviewed and tested.