### PR TITLE
Fix RequestContext failing the first time if tmp directory doesn't exist

### DIFF
--- a/lua/99/request-context.lua
+++ b/lua/99/request-context.lua
@@ -129,7 +129,10 @@ function RequestContext:save_prompt(prompt)
   local prompt_file = self.tmp_file .. "-prompt"
 
   local dir = vim.fs.dirname(prompt_file)
-  vim.fn.mkdir(dir, "p")
+
+  if dir and not vim.uv.fs_stat(dir) then
+    pcall(vim.uv.fs_mkdir, dir, 493)
+  end
 
   local file = io.open(prompt_file, "w")
   if file then


### PR DESCRIPTION
When using 99 for the first time in a project without a temporary directory, the `RequestContext:save_prompt` will fail. It fixes itself the next time because the folder has been created.

This change makes sure that the directory exists so that it succeeds the first time.