### PR TITLE
fix(lsp): remove debug code in lsp.lua causing init failure

### DIFF
--- a/lua/99/editor/lsp.lua
+++ b/lua/99/editor/lsp.lua
@@ -1041,11 +1041,6 @@ function Lsp._format_exports(
   return table.concat(out, "\n")
 end
 
-local imports = ts.imports(0)
-Lsp.stringify_definition_exports_from_node(0, imports[1], function(s)
-  print("s", s.results)
-end)
-
 return {
   Lsp = Lsp,
 }


### PR DESCRIPTION
This PR removes code that was causing the plugin to crash during initialization in headless and Nix environments.

The removed code triggered a logger assertion because it attempted to execute logic before a session ID was established. 

Closes #103