### PR TITLE
Clarify that alternate providers are under the `_99.Providers` object

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ I make the assumption you are using Lazy
             local cwd = vim.uv.cwd()
             local basename = vim.fs.basename(cwd)
 			_99.setup({
-                -- provider = _99.ClaudeCodeProvider,  -- default: OpenCodeProvider
+                -- provider = _99.Providers.ClaudeCodeProvider,  -- default: OpenCodeProvider
 				logger = {
 					level = _99.DEBUG,
 					path = "/tmp/" .. basename .. ".99.debug",


### PR DESCRIPTION
Just spent too much time trying to debug why `_99.CursorAgentProvider` was still trying to use `opencode` CLI command. This tiny change would have saved me.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or behavioral impact.
> 
> **Overview**
> Updates the README configuration example to reference alternate providers via `_99.Providers.*` (e.g., `ClaudeCodeProvider`) instead of `_99.*`, aligning the docs with the actual API and reducing confusion when switching away from the default provider.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8f5be12c59963c8f8254bd759b011f95730da889. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->