### PR TITLE
feat: add Gemini CLI as a provider

### DIFF
--- a/lua/99/providers.lua
+++ b/lua/99/providers.lua
@@ -236,10 +236,43 @@ function KiroProvider._get_default_model()
   return "claude-sonnet-4.5"
 end
 
+--- @class GeminiCLIProvider : _99.Providers.BaseProvider
+local GeminiCLIProvider = setmetatable({}, { __index = BaseProvider })
+
+--- @param query string
+--- @param request _99.Request
+--- @return string[]
+function GeminiCLIProvider._build_command(_, query, request)
+  return {
+    "gemini",
+    "--approval-mode",
+    -- Allow writing to temp files by default. See:
+    -- https://geminicli.com/docs/core/policy-engine/#default-policies
+    "auto_edit",
+    "--model",
+    request.context.model,
+    "--prompt",
+    query,
+  }
+end
+
+--- @return string
+function GeminiCLIProvider._get_provider_name()
+  return "GeminiCLIProvider"
+end
+
+--- @return string
+function GeminiCLIProvider._get_default_model()
+  -- Default to auto-routing between pro and flash. See:
+  -- https://geminicli.com/docs/cli/model/
+  return "auto"
+end
+
 return {
   BaseProvider = BaseProvider,
   OpenCodeProvider = OpenCodeProvider,
   ClaudeCodeProvider = ClaudeCodeProvider,
   CursorAgentProvider = CursorAgentProvider,
   KiroProvider = KiroProvider,
+  GeminiCLIProvider = GeminiCLIProvider,
 }

--- a/lua/99/test/providers_spec.lua
+++ b/lua/99/test/providers_spec.lua
@@ -66,6 +66,27 @@ describe("providers", function()
     end)
   end)
 
+  describe("GeminiCLIProvider", function()
+    it("builds correct command with model", function()
+      local request = { context = { model = "gemini-2.5-pro" } }
+      local cmd =
+        Providers.GeminiCLIProvider._build_command(nil, "test query", request)
+      eq({
+        "gemini",
+        "--approval-mode",
+        "auto_edit",
+        "--model",
+        "gemini-2.5-pro",
+        "--prompt",
+        "test query",
+      }, cmd)
+    end)
+
+    it("has correct default model", function()
+      eq("auto", Providers.GeminiCLIProvider._get_default_model())
+    end)
+  end)
+
   describe("provider integration", function()
     it("can be set as provider override", function()
       local _99 = require("99")
@@ -108,6 +129,17 @@ describe("providers", function()
       end
     )
 
+    it(
+      "uses GeminiCLIProvider default model when provider specified but no model",
+      function()
+        local _99 = require("99")
+
+        _99.setup({ provider = Providers.GeminiCLIProvider })
+        local state = _99.__get_state()
+        eq("auto", state.model)
+      end
+    )
+
     it("uses custom model when both provider and model specified", function()
       local _99 = require("99")
 
@@ -125,6 +157,7 @@ describe("providers", function()
       eq("function", type(Providers.OpenCodeProvider.make_request))
       eq("function", type(Providers.ClaudeCodeProvider.make_request))
       eq("function", type(Providers.CursorAgentProvider.make_request))
+      eq("function", type(Providers.GeminiCLIProvider.make_request))
     end)
   end)
 end)


### PR DESCRIPTION
Adding Gemini CLI support. Tested locally but YMMV.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a new provider path and associated tests without changing core request execution logic; main risk is runtime differences/availability of the external `gemini` CLI.
> 
> **Overview**
> Adds a new `GeminiCLIProvider` that shells out to the `gemini` CLI using `--approval-mode auto_edit`, passes through the configured model, and prompts via `--prompt`.
> 
> Exports the provider and extends tests to cover command construction, default model selection (`auto`), and integration with `setup()`/`BaseProvider.make_request`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f98529b6dabfcd3126a031f431d7469fb2d5aaf1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->