### PR TITLE
doc: add GeminiCLIProvider to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,10 +152,11 @@ Referenced content is automatically resolved and injected into the AI context. R
 | `OpenCodeProvider` (default) | `opencode` | `opencode/claude-sonnet-4-5` |
 | `ClaudeCodeProvider` | `claude` | `claude-sonnet-4-5` |
 | `CursorAgentProvider` | `cursor-agent` | `sonnet-4.5` |
+| `GeminiCLIProvider` | `gemini` | `auto` |
 
 ```lua
 _99.setup({
-    provider = _99.ClaudeCodeProvider,
+    provider = _99.Providers.ClaudeCodeProvider,
     -- model is optional, overrides the provider's default
     model = "claude-sonnet-4-5",
 })


### PR DESCRIPTION
Update README for #121.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes; no runtime or behavioral impact.
> 
> **Overview**
> Updates `README.md` to document the new `GeminiCLIProvider` option in the Providers table, including its `gemini` CLI tool and default model.
> 
> Fixes the setup example to reference providers via `_99.Providers.*` instead of `_99.*` (e.g., `_99.Providers.ClaudeCodeProvider`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f8c713ca43a160c41910ad05f4dab26548aa892d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->