### PR TITLE
Enhance error handling and logging in providers.lua

### DIFF
--- a/lua/99/providers.lua
+++ b/lua/99/providers.lua
@@ -3,7 +3,6 @@
 --- @field on_stderr fun(line: string): nil
 --- @field on_complete fun(status: _99.Request.ResponseState, res: string): nil
 --- @field on_start fun(): nil
-
 --- @param fn fun(...: any): nil
 --- @return fun(...: any): nil
 local function once(fn)
@@ -29,7 +28,6 @@ function BaseProvider:_retrieve_response(request)
   local success, result = pcall(function()
     return vim.fn.readfile(tmp)
   end)
-
   if not success then
     logger:error(
       "retrieve_results: failed to read file",
@@ -40,10 +38,8 @@ function BaseProvider:_retrieve_response(request)
     )
     return false, ""
   end
-
   local str = table.concat(result, "\n")
   logger:debug("retrieve_results", "results", str)
-
   return true, str
 end
 
@@ -52,10 +48,9 @@ end
 --- @param observer _99.Providers.Observer
 function BaseProvider:make_request(query, request, observer)
   observer.on_start()
-
   local logger = request.logger:set_area(self:_get_provider_name())
   logger:debug("make_request", "tmp_file", request.context.tmp_file)
-
+  local stderr_accum = {}
   local once_complete = once(
     --- @param status "success" | "failed" | "cancelled"
     ---@param text string
@@ -64,10 +59,8 @@ function BaseProvider:make_request(query, request, observer)
       observer.on_complete(status, text)
     end
   )
-
   local command = self:_build_command(query, request)
   logger:debug("make_request", "command", command)
-
   local proc = vim.system(
     command,
     {
@@ -95,6 +88,9 @@ function BaseProvider:make_request(query, request, observer)
           logger:debug("stderr#error", "err", err)
         end
         if not err then
+          if data then
+            table.insert(stderr_accum, data)
+          end
           observer.on_stderr(data)
         end
       end),
@@ -106,10 +102,11 @@ function BaseProvider:make_request(query, request, observer)
         return
       end
       if obj.code ~= 0 then
+        local stderr_text = table.concat(stderr_accum, "")
         local str =
-          string.format("process exit code: %d\n%s", obj.code, vim.inspect(obj))
+          string.format("process exit code: %d\n%s\n%s", obj.code, stderr_text, vim.inspect(obj))
         once_complete("failed", str)
-        logger:fatal(
+        logger:error(
           self:_get_provider_name() .. " make_query failed",
           "obj from results",
           obj
@@ -129,7 +126,6 @@ function BaseProvider:make_request(query, request, observer)
       end
     end)
   )
-
   request:_set_process(proc)
 end
 


### PR DESCRIPTION
I have made the following changes to fix the hanging issue:

1. The primary change is replacing logger:fatal with logger:error. logger:error simply writes to the log file and continues execution. This ensures the callback finishes naturally, allowing the once_complete function to trigger the UI cleanup.

2. Created stderr_accum table as a local variable. It exists only while a request is active so I believe buffering this in memory is negligible and safe.

3. I have not changed the function signatures of make_request or the observer. The rest of the application (which expects on_complete to be called with a status string) receives exactly that.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized changes to provider process error handling and logging; primary risk is slightly different error reporting/verbosity on failures.
> 
> **Overview**
> Improves provider request failure handling in `providers.lua` by buffering `stderr` output during `vim.system` execution and including it in the `on_complete("failed", ...)` message when the process exits non-zero.
> 
> Downgrades the failure log from `logger:fatal` to `logger:error` in the non-zero exit path to avoid aborting execution while still reporting the error, helping ensure completion callbacks/UI cleanup run reliably.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 78e686eb958e057d158508599cc6f29e82fcb42f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->