### PR TITLE
docs: remove comment as blink is supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,8 +93,7 @@ I make the assumption you are using Lazy
                         -- exclude = { ".env", ".env.*", "node_modules", ".git", ... },
                     },
 
-                    --- What autocomplete do you use.  We currently only
-                    --- support cmp right now
+                    --- What autocomplete you use.
                     source = "cmp" | "blink",
                 },
 


### PR DESCRIPTION
I assume blink.cmp works now via #83 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change; no runtime behavior or API changes.
> 
> **Overview**
> Updates `README.md` completion configuration docs to remove the outdated note that only `cmp` is supported, reflecting support for `blink` as an autocomplete source.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cfd930e3c7fd1572b16d6a3898b52af730920087. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->