### PR TITLE
Add markdown support

### DIFF
--- a/lua/99/language/markdown.lua
+++ b/lua/99/language/markdown.lua
@@ -1,0 +1,6 @@
+local M = {}
+M.names = {}
+function M.log_item(item_name)
+  return item_name
+end
+return M

--- a/lua/99/state.lua
+++ b/lua/99/state.lua
@@ -46,7 +46,7 @@ local function create()
     prompts = require("99.prompt-settings"),
     ai_stdout_rows = 3,
     show_in_flight_requests = false,
-    languages = { "lua", "go", "java", "elixir", "cpp", "ruby" },
+    languages = { "lua", "go", "java", "elixir", "cpp", "ruby", "markdown" },
     display_errors = false,
     provider_override = nil,
     auto_add_skills = false,

--- a/queries/markdown/99-function.scm
+++ b/queries/markdown/99-function.scm
@@ -1,0 +1,14 @@
+; Headings are primary functions
+(atx_heading) @context.function
+
+; Heading with its content as body
+(atx_heading
+  (section) @context.body)
+
+(setext_heading) @context.function
+
+(setext_heading
+  (section) @context.body)
+
+; Fenced code blocks as standalone functions (for individual selection)
+(fenced_code_block) @context.function

--- a/queries/markdown/99-imports.scm
+++ b/queries/markdown/99-imports.scm
@@ -1,0 +1,10 @@
+(link_reference_definition
+  (link_label) @import.name) @import.decl
+
+(inline
+  (inline_link
+    (link_text) @import.name)) @import.decl
+
+(inline
+  (image
+    (image_description) @import.name)) @import.decl

--- a/queries/markdown/99-scope.scm
+++ b/queries/markdown/99-scope.scm
@@ -1,0 +1,7 @@
+; Content sections between headings
+(section) @context.scope
+
+; Code blocks as their own scopes
+(fenced_code_block) @context.scope
+
+(block_quote) @context.scope


### PR DESCRIPTION
This adds markdown support for 99, enabling AI-assisted editing for documentation, technical writing, and mixed content workflows. 

#### Changes
1. Language registration (state.lua) - Added "markdown" to supported languages
2. Language module (language/markdown.lua) - Basic language interface
3. Tree-sitter queries (queries/markdown/):
   - 99-function.scm - Treats headings and code blocks as editable units
   - 99-imports.scm - Extracts links as references
   - 99-scope.scm - Defines content boundaries
  
#### What It Enables
- <leader>9v on a heading -> AI edits the entire section
- <leader>9v in code block -> AI edits just the code
- <leader>9s -> AI sees current section + all links