### PR TITLE
fix: validate line exists before setting extmark in mark_above_range

### DIFF
--- a/lua/99/geo.lua
+++ b/lua/99/geo.lua
@@ -194,6 +194,9 @@ end
 --- @param mark _99.Mark
 --- @return _99.Point
 function Point.from_mark(mark)
+  if not mark.id then
+    return Point:from_1_based(0, 0)
+  end
   --- buf extmark by id is a 0 based api
   local pos =
     vim.api.nvim_buf_get_extmark_by_id(mark.buffer, mark.nsid, mark.id, {})

--- a/lua/99/ops/marks.lua
+++ b/lua/99/ops/marks.lua
@@ -25,9 +25,13 @@ function Mark.mark_above_range(range)
   if above == line then
     id = vim.api.nvim_buf_set_extmark(buffer, nsid, above, 0, {})
   else
-    local text = vim.api.nvim_buf_get_lines(buffer, above, above + 1, false)[1]
-    local ending = #text
-    id = vim.api.nvim_buf_set_extmark(buffer, nsid, above, ending, {})
+    local lines = vim.api.nvim_buf_get_lines(buffer, above, above + 1, false)
+    local text = lines[1]
+    if text then
+      local ending = #text
+      id = vim.api.nvim_buf_set_extmark(buffer, nsid, above, ending, {})
+    end
+    -- If text is nil, id remains nil and is_valid() will return false
   end
 
   return setmetatable({
@@ -48,6 +52,9 @@ end
 
 --- @return boolean
 function Mark:is_valid()
+  if not self.id then
+    return false
+  end
   local pos =
     vim.api.nvim_buf_get_extmark_by_id(self.buffer, self.nsid, self.id, {})
   return #pos > 0
@@ -121,6 +128,9 @@ end
 
 --- @param lines string[]
 function Mark:set_virtual_text(lines)
+  if not self.id then
+    return
+  end
   local pos = vim.api.nvim_buf_get_extmark_by_id(self.buffer, nsid, self.id, {})
   assert(#pos > 0, "extmark is broken.  it does not exist")
   local row, col = pos[1], pos[2]
@@ -147,6 +157,9 @@ function Mark:set_text_at_mark(text)
 end
 
 function Mark:delete()
+  if not self.id then
+    return
+  end
   vim.api.nvim_buf_del_extmark(self.buffer, nsid, self.id)
 end
 


### PR DESCRIPTION
Fixes a crash when mark_above_range attempts to set an extmark on a line that no longer exists due to buffer modifications.

## Problem
The original code assumed nvim_buf_get_lines() would always return a valid line:

```lua
local text = vim.api.nvim_buf_get_lines(buffer, above, above + 1, false)[1]
local ending = #text
```

When the buffer is modified (e.g., lines deleted during async operations), nvim_buf_get_lines() returns an empty table, causing text to be nil. Attempting to get the length of nil crashes with:

```
Error: Invalid 'line': out of range
```

This crash prevents the proper error handling in over-range.lua (lines 69-76) from running.

## Solution
Added validation to check if the line exists before creating the extmark. If the line doesn't exist, the mark is not created (id remains nil). Updated is_valid() to return false when id is nil, allowing the existing validation logic in over-range.lua to properly detect the invalid mark and display the appropriate error message.

This approach ensures that when a buffer is modified and the target line no longer exists, the system correctly identifies the mark as invalid rather than creating a mark at an incorrect position.

## Testing
- All existing tests pass (11/11 marks tests)
- Linting passes (0 warnings/errors)
- Formatting passes (stylua check on marks.lua)
- Manually verified fix resolves the crash during visual selection operations
- Verified that invalid marks are properly detected by is_valid() check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small defensive changes around Neovim extmark creation/lookup; behavior change is limited to treating missing marks as invalid instead of erroring.
> 
> **Overview**
> Prevents crashes when creating or operating on extmarks after buffer edits by allowing marks to be *invalid* (`id == nil`) and short-circuiting extmark API calls.
> 
> `Mark.mark_above_range` now checks that the target line exists before computing its end column and setting an extmark, and `Mark:is_valid`, `Mark:set_virtual_text`, `Mark:delete`, and `Point.from_mark` now explicitly handle missing `id` values.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 899db4e773a001a046c3eb33d621033ba400789f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->