### PR TITLE
Fixes claude `--print` which does not respect TEMP_FILE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 tmp
 /.cursor/
+.claude/settings.local.json

--- a/lua/99/providers.lua
+++ b/lua/99/providers.lua
@@ -27,6 +27,23 @@ function BaseProvider.fetch_models(callback)
   callback(nil, "This provider does not support listing models")
 end
 
+--- @return boolean
+function BaseProvider._stdout_as_response()
+  return false
+end
+
+--- @param text string
+--- @return string
+function BaseProvider.strip_markdown_fences(text)
+  local lines = vim.split(text, "\n")
+  if #lines >= 2 and lines[1]:match("^```%w*$") and lines[#lines]:match("^```$") then
+    table.remove(lines, 1)
+    table.remove(lines, #lines)
+    return table.concat(lines, "\n")
+  end
+  return text
+end
+
 --- @param context _99.Prompt
 function BaseProvider:_retrieve_response(context)
   local logger = context.logger:set_area(self:_get_provider_name())
@@ -72,6 +89,9 @@ function BaseProvider:make_request(query, context, observer)
   local command = self:_build_command(query, context)
   logger:debug("make_request", "command", command)
 
+  local stdout_chunks = {}
+  local capture_stdout = self._stdout_as_response()
+
   local proc = vim.system(
     command,
     {
@@ -86,6 +106,9 @@ function BaseProvider:make_request(query, context, observer)
           logger:debug("stdout#error", "err", err)
         end
         if not err and data then
+          if capture_stdout then
+            table.insert(stdout_chunks, data)
+          end
           observer.on_stdout(data)
         end
       end),
@@ -120,6 +143,13 @@ function BaseProvider:make_request(query, context, observer)
         )
       else
         vim.schedule(function()
+          if capture_stdout then
+            local raw = table.concat(stdout_chunks, "")
+            local cleaned = BaseProvider.strip_markdown_fences(vim.trim(raw))
+            if cleaned ~= "" then
+              vim.fn.writefile(vim.split(cleaned, "\n"), context.tmp_file)
+            end
+          end
           local ok, res = self:_retrieve_response(context)
           if ok then
             once_complete("success", res)
@@ -200,6 +230,10 @@ function ClaudeCodeProvider._get_provider_name()
   return "ClaudeCodeProvider"
 end
 
+function ClaudeCodeProvider._stdout_as_response()
+  return true
+end
+
 --- @return string
 function ClaudeCodeProvider._get_default_model()
   return "claude-sonnet-4-5"
@@ -236,6 +270,10 @@ end
 --- @return string
 function CursorAgentProvider._get_provider_name()
   return "CursorAgentProvider"
+end
+
+function CursorAgentProvider._stdout_as_response()
+  return true
 end
 
 --- @return string

--- a/lua/99/test/providers_spec.lua
+++ b/lua/99/test/providers_spec.lua
@@ -160,4 +160,66 @@ describe("providers", function()
       eq("function", type(Providers.GeminiCLIProvider.make_request))
     end)
   end)
+
+  describe("stdout_as_response", function()
+    it("is false for providers that write to temp file", function()
+      eq(false, Providers.OpenCodeProvider._stdout_as_response())
+      eq(false, Providers.KiroProvider._stdout_as_response())
+      eq(false, Providers.GeminiCLIProvider._stdout_as_response())
+    end)
+
+    it("is true for providers using --print flag", function()
+      eq(true, Providers.ClaudeCodeProvider._stdout_as_response())
+      eq(true, Providers.CursorAgentProvider._stdout_as_response())
+    end)
+  end)
+
+  describe("strip_markdown_fences", function()
+    it("strips code fences with language identifier", function()
+      local input = "```python\nis_inventory: bool,\n```"
+      eq(
+        "is_inventory: bool,",
+        Providers.BaseProvider.strip_markdown_fences(input)
+      )
+    end)
+
+    it("strips code fences without language identifier", function()
+      local input = "```\nis_inventory: bool,\n```"
+      eq(
+        "is_inventory: bool,",
+        Providers.BaseProvider.strip_markdown_fences(input)
+      )
+    end)
+
+    it("returns text unchanged when no fences present", function()
+      local input = "is_inventory: bool,"
+      eq(
+        "is_inventory: bool,",
+        Providers.BaseProvider.strip_markdown_fences(input)
+      )
+    end)
+
+    it("handles multi-line content inside fences", function()
+      local input = "```lua\nlocal x = 1\nlocal y = 2\nreturn x + y\n```"
+      eq(
+        "local x = 1\nlocal y = 2\nreturn x + y",
+        Providers.BaseProvider.strip_markdown_fences(input)
+      )
+    end)
+
+    it("handles empty content inside fences", function()
+      local input = "```\n```"
+      eq("", Providers.BaseProvider.strip_markdown_fences(input))
+    end)
+
+    it("trims to empty string for whitespace-only input", function()
+      eq("", vim.trim(Providers.BaseProvider.strip_markdown_fences("\n")))
+      eq("", vim.trim(Providers.BaseProvider.strip_markdown_fences("  \n  ")))
+    end)
+
+    it("does not strip fences that are not wrapping the whole text", function()
+      local input = "some text\n```python\ncode\n```\nmore text"
+      eq(input, Providers.BaseProvider.strip_markdown_fences(input))
+    end)
+  end)
 end)


### PR DESCRIPTION
## Why

The ClaudeCodeProvider (and CursorAgentProvider) use claude `--print` which is a non-interactive mode. The prompt instructs Claude to write  replacement code to a `TEMP_FILE`, but `--print` mode may output the response to stdout instead of writing to the file. The plugin only reads results from the temp file via `_retrieve_response`, so when the response comes via stdout it gets silently discarded. This results in "response was empty, visual replacement aborted" for visual operations.

Additionally, `--print` mode with `--dangerously-skip-permissions` can behave non-deterministically — sometimes Claude outputs code to stdout (wrapped in markdown fences), sometimes it uses tool use to write directly to the temp file. Both paths need to work.

## What

Added stdout capture support for providers that use `--print` mode:

- `_stdout_as_response()` — new method on `BaseProvider` (returns `false`), overridden to `true` on `ClaudeCodeProvider` and `CursorAgentProvider`. Signals that the provider may return results via stdout rather than writing to the temp file.
- `strip_markdown_fences(text)` — utility that strips ```lang ... ``` wrappers that `--print` mode adds around code output.
- `make_request` modification — when `_stdout_as_response()` is true, accumulates stdout chunks during the request. On completion, if the accumulated stdout is non-empty (after trimming and fence-stripping), writes it to the temp file. If stdout is empty (meaning Claude wrote to the temp file directly via tool use), the existing temp file content is preserved.

## Testing

Unit tests added:
- `_stdout_as_response()` returns correct values for all providers
- `strip_markdown_fences` handles: fences with/without language identifiers, no fences, multi-line content, empty content, fences that don't wrap the whole text, whitespace-only input

Manually tested via: `nvim --cmd "set rtp^=$(pwd)"` and then using visual.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how provider output is captured/written to the temp file for `claude`/`cursor-agent` `--print` mode, which can affect request completion behavior and response parsing. Covered by unit tests but touches core provider I/O paths.
> 
> **Overview**
> Fixes visual operations for providers using `--print` by **capturing stdout as the response when the CLI doesn’t write to `TEMP_FILE`**.
> 
> Adds `BaseProvider._stdout_as_response()` and `BaseProvider.strip_markdown_fences()`, updates `make_request` to optionally buffer stdout and write cleaned output back to the temp file on success, and enables this behavior for `ClaudeCodeProvider` and `CursorAgentProvider`. Includes new unit tests for stdout-capture configuration and fence stripping, and updates `.gitignore` to exclude `.claude/settings.local.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2aaf84221b22951824cfeeb909b55e40dc492db8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->