### PR TITLE
feat: adds github copilot provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -432,6 +432,7 @@ Referenced content is automatically resolved and injected into the AI context. R
 | `ClaudeCodeProvider` | `claude` | `claude-sonnet-4-5` |
 | `CursorAgentProvider` | `cursor-agent` | `sonnet-4.5` |
 | `GeminiCLIProvider` | `gemini` | `auto` |
+| `GitHubCopilotProvider` | `copilot` | `claude-sonnet-4.5` |
 
 ```lua
 _99.setup({

--- a/lua/99/providers.lua
+++ b/lua/99/providers.lua
@@ -63,8 +63,8 @@ function BaseProvider:make_request(query, context, observer)
   logger:debug("make_request", "tmp_file", context.tmp_file)
 
   local once_complete = once(
-    --- @param status "success" | "failed" | "cancelled"
-    ---@param text string
+  --- @param status "success" | "failed" | "cancelled"
+  ---@param text string
     function(status, text)
       observer.on_complete(status, text)
     end
@@ -112,7 +112,7 @@ function BaseProvider:make_request(query, context, observer)
       end
       if obj.code ~= 0 then
         local str =
-          string.format("process exit code: %d\n%s", obj.code, vim.inspect(obj))
+            string.format("process exit code: %d\n%s", obj.code, vim.inspect(obj))
         once_complete("failed", str)
         logger:fatal(
           self:_get_provider_name() .. " make_query failed",
@@ -325,6 +325,63 @@ function GeminiCLIProvider._get_default_model()
   return "auto"
 end
 
+--- @class GitHubCopilotProvider : _99.Providers.BaseProvider
+local GitHubCopilotProvider = setmetatable({}, { __index = BaseProvider })
+
+--- @param query string
+--- @param context _99.Prompt
+--- @return string[]
+function GitHubCopilotProvider._build_command(_, query, context)
+  return {
+    "copilot",
+    "--model",
+    context.model,
+    "--prompt",
+    query,
+  }
+end
+
+--- @return string
+function GitHubCopilotProvider._get_provider_name()
+  return "GitHubCopilotProvider"
+end
+
+--- @return string
+function GitHubCopilotProvider._get_default_model()
+  return "claude-sonnet-4.5"
+end
+
+-- TODO: update with cli command when support exists
+-- GitHub issue link: https://github.com/github/copilot-cli/issues/700
+-- Current list based off https://docs.github.com/en/copilot/reference/ai-models/supported-models
+function GitHubCopilotProvider.fetch_models(callback)
+  callback({
+    "claude-haiku-4.5",
+    "claude-opus-4.5",
+    "claude-opus-4.6",
+    "claude-sonnet-4",
+    "claude-sonnet-4.5",
+    "claude-sonnet-4.6",
+    "gemini-2.5-pro",
+    "gemini-3-flash",
+    "gemini-3-pro",
+    "gemini-3.1-pro",
+    "gpt-4.1",
+    "gpt-4o",
+    "gpt-5-min",
+    "gpt-5.1",
+    "gpt-5.1-codex",
+    "gpt-5.1-codex-mini",
+    "gpt-5.1-codex-max",
+    "gpt-5.2",
+    "gpt-5.2-codex",
+    "gpt-5.3-codex",
+    "grok-code-fast",
+    "raptor-mini",
+    "goldeneye"
+  }, nil)
+end
+
 return {
   BaseProvider = BaseProvider,
   OpenCodeProvider = OpenCodeProvider,
@@ -332,4 +389,5 @@ return {
   CursorAgentProvider = CursorAgentProvider,
   KiroProvider = KiroProvider,
   GeminiCLIProvider = GeminiCLIProvider,
+  GitHubCopilotProvider = GitHubCopilotProvider,
 }

--- a/lua/99/test/providers_spec.lua
+++ b/lua/99/test/providers_spec.lua
@@ -7,7 +7,7 @@ describe("providers", function()
     it("builds correct command with model", function()
       local request = { model = "anthropic/claude-sonnet-4-5" }
       local cmd =
-        Providers.OpenCodeProvider._build_command(nil, "test query", request)
+          Providers.OpenCodeProvider._build_command(nil, "test query", request)
       eq({
         "opencode",
         "run",
@@ -31,7 +31,7 @@ describe("providers", function()
     it("builds correct command with model", function()
       local request = { model = "anthropic/claude-sonnet-4-5" }
       local cmd =
-        Providers.ClaudeCodeProvider._build_command(nil, "test query", request)
+          Providers.ClaudeCodeProvider._build_command(nil, "test query", request)
       eq({
         "claude",
         "--dangerously-skip-permissions",
@@ -51,7 +51,7 @@ describe("providers", function()
     it("builds correct command with model", function()
       local request = { model = "anthropic/claude-sonnet-4-5" }
       local cmd =
-        Providers.CursorAgentProvider._build_command(nil, "test query", request)
+          Providers.CursorAgentProvider._build_command(nil, "test query", request)
       eq({
         "cursor-agent",
         "--model",
@@ -70,7 +70,7 @@ describe("providers", function()
     it("builds correct command with model", function()
       local request = { model = "gemini-2.5-pro" }
       local cmd =
-        Providers.GeminiCLIProvider._build_command(nil, "test query", request)
+          Providers.GeminiCLIProvider._build_command(nil, "test query", request)
       eq({
         "gemini",
         "--approval-mode",
@@ -84,6 +84,25 @@ describe("providers", function()
 
     it("has correct default model", function()
       eq("auto", Providers.GeminiCLIProvider._get_default_model())
+    end)
+  end)
+
+  describe("GitHubCopilotProvider", function()
+    it("builds correct command with model", function()
+      local request = { model = "claude-sonnet-4.5" }
+      local cmd =
+          Providers.GitHubCopilotProvider._build_command(nil, "test query", request)
+      eq({
+        "copilot",
+        "--model",
+        "claude-sonnet-4.5",
+        "--prompt",
+        "test query",
+      }, cmd)
+    end)
+
+    it("has correct default model", function()
+      eq("claude-sonnet-4.5", Providers.GitHubCopilotProvider._get_default_model())
     end)
   end)
 
@@ -140,6 +159,17 @@ describe("providers", function()
       end
     )
 
+    it(
+      "uses GitHubCopilotProvider default model when provider specified but no model",
+      function()
+        local _99 = require("99")
+
+        _99.setup({ provider = Providers.GitHubCopilotProvider })
+        local state = _99.__get_state()
+        eq("claude-sonnet-4.5", state.model)
+      end
+    )
+
     it("uses custom model when both provider and model specified", function()
       local _99 = require("99")
 
@@ -158,6 +188,7 @@ describe("providers", function()
       eq("function", type(Providers.ClaudeCodeProvider.make_request))
       eq("function", type(Providers.CursorAgentProvider.make_request))
       eq("function", type(Providers.GeminiCLIProvider.make_request))
+      eq("function", type(Providers.GitHubCopilotProvider.make_request))
     end)
   end)
 end)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Mostly additive change that introduces a new opt-in provider and updates docs/tests; main risk is runtime behavior depends on the external `copilot` CLI and the hardcoded model list staying in sync.
> 
> **Overview**
> Adds a new `GitHubCopilotProvider` that routes requests through the `copilot` CLI (including a default model of `claude-sonnet-4.5`) and exposes a hardcoded `fetch_models` list until the CLI supports enumeration.
> 
> Updates the README provider matrix and extends provider tests to cover Copilot command construction, default model selection, and integration with `_99.setup`/`make_request` availability.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b7225f4eec53b22f2355d7598be9d83341423951. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->