### PR TITLE
feat: add new snacks picker extension

### DIFF
--- a/lua/99/extensions/pickers.lua
+++ b/lua/99/extensions/pickers.lua
@@ -2,6 +2,18 @@ local _99 = require("99")
 
 local M = {}
 
+--- @param list string[]
+--- @param value string
+--- @return number
+function M.index_of(list, value)
+  for i, item in ipairs(list) do
+    if item == value then
+      return i
+    end
+  end
+  return 1
+end
+
 local function is_selectable_provider(provider)
   return type(provider) == "table"
     and type(provider._get_provider_name) == "function"

--- a/lua/99/extensions/snacks.lua
+++ b/lua/99/extensions/snacks.lua
@@ -1,0 +1,71 @@
+local pickers_util = require("99.extensions.pickers")
+
+local M = {}
+
+---@param provider _99.Providers.BaseProvider?
+function M.select_model(provider)
+  local ok, snacks = pcall(require, "snacks")
+  if
+    not ok
+    or not snacks.picker
+    or type(snacks.picker.select) ~= "function"
+  then
+    vim.notify(
+      "99: snacks.nvim picker is required for this extension",
+      vim.log.levels.ERROR
+    )
+    return
+  end
+
+  pickers_util.get_models(provider, function(models, current)
+    snacks.picker.select(models, {
+      prompt = "99: Select Model (current: " .. current .. ")",
+      snacks = {
+        on_show = function(picker)
+          picker.list:view(pickers_util.index_of(models, current))
+        end,
+      },
+    }, function(selected)
+      if not selected then
+        return
+      end
+      pickers_util.on_model_selected(selected)
+    end)
+  end)
+end
+
+function M.select_provider()
+  local ok, snacks = pcall(require, "snacks")
+  if
+    not ok
+    or not snacks.picker
+    or type(snacks.picker.select) ~= "function"
+  then
+    vim.notify(
+      "99: snacks.nvim picker is required for this extension",
+      vim.log.levels.ERROR
+    )
+    return
+  end
+
+  local info = pickers_util.get_providers()
+
+  snacks.picker.select(info.names, {
+    prompt = "99: Select Provider (current: " .. info.current .. ")",
+    format_item = function(item)
+      return item
+    end,
+    snacks = {
+      on_show = function(picker)
+        picker.list:view(pickers_util.index_of(info.names, info.current))
+      end,
+    },
+  }, function(selected)
+    if not selected then
+      return
+    end
+    pickers_util.on_provider_selected(selected, info.lookup)
+  end)
+end
+
+return M

--- a/lua/99/extensions/telescope.lua
+++ b/lua/99/extensions/telescope.lua
@@ -2,18 +2,6 @@ local pickers_util = require("99.extensions.pickers")
 
 local M = {}
 
---- @param list string[]
---- @param value string
---- @return number
-local function index_of(list, value)
-  for i, item in ipairs(list) do
-    if item == value then
-      return i
-    end
-  end
-  return 1
-end
-
 --- @param provider _99.Providers.BaseProvider?
 function M.select_model(provider)
   local ok, pickers = pcall(require, "telescope.pickers")
@@ -34,7 +22,7 @@ function M.select_model(provider)
     pickers
       .new({}, {
         prompt_title = "99: Select Model (current: " .. current .. ")",
-        default_selection_index = index_of(models, current),
+        default_selection_index = pickers_util.index_of(models, current),
         finder = finders.new_table({ results = models }),
         sorter = conf.generic_sorter({}),
         attach_mappings = function(prompt_bufnr)
@@ -73,7 +61,7 @@ function M.select_provider()
   pickers
     .new({}, {
       prompt_title = "99: Select Provider (current: " .. info.current .. ")",
-      default_selection_index = index_of(info.names, info.current),
+      default_selection_index = pickers_util.index_of(info.names, info.current),
       finder = finders.new_table({ results = info.names }),
       sorter = conf.generic_sorter({}),
       attach_mappings = function(prompt_bufnr)


### PR DESCRIPTION
Added support for the popular snacks picker. Snacks can now be selected as a picker by following the same config patterns as fzf_lua & telescope

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a new optional extension and a small utility refactor; changes are localized to picker UI behavior with minimal impact on core functionality.
> 
> **Overview**
> Adds a new `snacks.nvim` picker extension (`extensions/snacks.lua`) that lets users pick the current model or provider via `snacks.picker.select`, including dependency checks and preselecting the current choice.
> 
> Refactors shared selection logic by moving `index_of` into `extensions/pickers.lua` and updating the Telescope extension to use the shared helper for `default_selection_index`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a15b14a6c559c098be4d5c50a87305d69eb0a4ea. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->