### PR TITLE
feat: add stdin support to providers, use stdin for OpenCodeProvider …

### DIFF
--- a/lua/99/providers.lua
+++ b/lua/99/providers.lua
@@ -19,9 +19,17 @@ end
 
 --- @class _99.Providers.BaseProvider
 --- @field _build_command fun(self: _99.Providers.BaseProvider, query: string, context: _99.Prompt): string[]
+--- @field _build_stdin fun(self: _99.Providers.BaseProvider, query: string, context: _99.Prompt): string|nil
 --- @field _get_provider_name fun(self: _99.Providers.BaseProvider): string
 --- @field _get_default_model fun(): string
 local BaseProvider = {}
+
+--- @param query string
+--- @param context _99.Prompt
+--- @return string|nil
+function BaseProvider:_build_stdin(_, _)
+  return nil
+end
 
 --- @param callback fun(models: string[]|nil, err: string|nil): nil
 function BaseProvider.fetch_models(callback)
@@ -71,12 +79,14 @@ function BaseProvider:make_request(query, context, observer)
   )
 
   local command = self:_build_command(query, context)
-  logger:debug("make_request", "command", command)
+  local stdin = self:_build_stdin(query, context)
+  logger:debug("make_request", "command", command, "has_stdin", stdin ~= nil)
 
   local proc = vim.system(
     command,
     {
       text = true,
+      stdin = stdin,
       stdout = vim.schedule_wrap(function(err, data)
         logger:debug("stdout", "data", data)
         if context:is_cancelled() then
@@ -144,7 +154,7 @@ local OpenCodeProvider = setmetatable({}, { __index = BaseProvider })
 --- @param query string
 --- @param context _99.Prompt
 --- @return string[]
-function OpenCodeProvider._build_command(_, query, context)
+function OpenCodeProvider._build_command(_, _, context)
   return {
     "opencode",
     "run",
@@ -152,8 +162,13 @@ function OpenCodeProvider._build_command(_, query, context)
     "build",
     "-m",
     context.model,
-    query,
   }
+end
+
+--- @param query string
+--- @return string
+function OpenCodeProvider._build_stdin(_, query, _)
+  return query
 end
 
 --- @return string

--- a/lua/99/test/providers_spec.lua
+++ b/lua/99/test/providers_spec.lua
@@ -15,8 +15,13 @@ describe("providers", function()
         "build",
         "-m",
         "anthropic/claude-sonnet-4-5",
-        "test query",
       }, cmd)
+    end)
+
+    it("passes query via stdin", function()
+      local stdin =
+        Providers.OpenCodeProvider._build_stdin(nil, "test query", nil)
+      eq("test query", stdin)
     end)
 
     it("has correct default model", function()


### PR DESCRIPTION
Pass query via stdin instead of a CLI positional arg in OpenCodeProvider to avoid shell argument size limits. 

BaseProvider gains a _build_stdin hook (returns nil by default) that subclasses can override; make_request now forwards the result to vim.system's stdin option.

This is error:
```
Error in BufWriteCmd Autocommands for "<buffer=3>":                                                                                                                                                                              
Lua callback: vim/_system.lua:0: E2BIG: argument list too long                                                                                                                                                                   
stack traceback:                                                                                                                                                                                                                 
        [C]: in function 'error'                                                                                                                                                                                                 
        vim/_system.lua: in function ''                                                                                                                                                                                          
        vim/_system.lua: in function 'system'                                                                                                                                                                                    
        /home/tieu/.local/share/nvim/lazy/99/lua/99/providers.lua:76: in function 'make_request'                                                                                                                                 
        /home/tieu/.local/share/nvim/lazy/99/lua/99/prompt.lua:300: in function 'start_request'         
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches request execution for all providers by wiring optional `stdin` into `vim.system`, which could affect provider invocation if stdin/args expectations differ. Change is small and covered by updated unit tests for `OpenCodeProvider`.
> 
> **Overview**
> Adds a new optional `BaseProvider:_build_stdin()` hook (default `nil`) and updates `BaseProvider:make_request()` to pass the returned value into `vim.system` as `stdin`.
> 
> Updates `OpenCodeProvider` to remove the query from its command args and instead provide it via `_build_stdin`, with accompanying test updates to assert the new behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a5687d385f80bfdce2478726128bc39a3ad1465a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->