### PR TITLE
Surface provider errors to the user via vim.notify

### DIFF
--- a/lua/99/ops/clean-up.lua
+++ b/lua/99/ops/clean-up.lua
@@ -24,6 +24,12 @@ M.make_observer = function(context, obs_or_fn)
     end,
     on_complete = function(status, res)
       pcall(obs.on_complete, status, res)
+      if status == "failed" then
+        vim.notify(
+          "99: provider failed\n" .. (res or "unknown error"),
+          vim.log.levels.ERROR
+        )
+      end
       vim.schedule(function()
         context:stop()
         context._99:sync()

--- a/lua/99/providers.lua
+++ b/lua/99/providers.lua
@@ -73,6 +73,8 @@ function BaseProvider:make_request(query, context, observer)
   local command = self:_build_command(query, context)
   logger:debug("make_request", "command", command)
 
+  local stderr_chunks = {}
+
   local proc = vim.system(
     command,
     {
@@ -99,7 +101,8 @@ function BaseProvider:make_request(query, context, observer)
         if err and err ~= "" then
           logger:debug("stderr#error", "err", err)
         end
-        if not err then
+        if not err and data then
+          table.insert(stderr_chunks, data)
           observer.on_stderr(data)
         end
       end),
@@ -111,8 +114,12 @@ function BaseProvider:make_request(query, context, observer)
         return
       end
       if obj.code ~= 0 then
-        local str =
-          string.format("process exit code: %d\n%s", obj.code, vim.inspect(obj))
+        local stderr_output = table.concat(stderr_chunks, "")
+        local str = string.format(
+          "process exit code: %d\nstderr: %s",
+          obj.code,
+          stderr_output ~= "" and stderr_output or "(no stderr output)"
+        )
         once_complete("failed", str)
         logger:fatal(
           self:_get_provider_name() .. " make_query failed",


### PR DESCRIPTION
## Summary

- When a provider process fails (non-zero exit code), the "Implementing" spinner silently vanishes with no feedback to the user
- Accumulate stderr output during the process lifetime and include it in the failure response, replacing the `vim.inspect(obj)` dump that contained no actionable info
- Add `vim.notify()` with `ERROR` level in the central `make_observer` `on_complete` handler so all operations (visual, search, vibe, tutorial) surface failures without needing individual changes

## Test plan

- [ ] Trigger a provider failure (e.g. OpenCode with no payment method, or a provider binary not on `$PATH`)
- [ ] Verify the error message appears via `vim.notify` with the stderr output
- [ ] Verify successful requests still work normally
- [ ] Verify cancelled requests don't trigger error notifications

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 679c1e7ba3962e1df9f52ec8de693a99883ecdef. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->