### PR TITLE
Adding MistralVibeCLI Provider support

### DIFF
--- a/lua/99/providers.lua
+++ b/lua/99/providers.lua
@@ -325,6 +325,33 @@ function GeminiCLIProvider._get_default_model()
   return "auto"
 end
 
+--- @class MistralVibeCLIProvider : _99.Providers.BaseProvider
+local MistralVibeCLIProvider = setmetatable({}, { __index = BaseProvider })
+
+--- @param query string
+--- @param context _99.Prompt
+--- @return string[]
+function MistralVibeCLIProvider._build_command(_, query, context)
+  return {
+    "vibe",
+    "--agent",
+    "auto-approve",
+    "--prompt",
+    query,
+  }
+end
+
+--- @return string
+function MistralVibeCLIProvider._get_provider_name()
+  return "MistralVibeCLIProvider"
+end
+
+--- @return string
+function MistralVibeCLIProvider._get_default_model()
+  -- Non selectable model, auto routing
+  return "auto"
+end
+
 return {
   BaseProvider = BaseProvider,
   OpenCodeProvider = OpenCodeProvider,
@@ -332,4 +359,5 @@ return {
   CursorAgentProvider = CursorAgentProvider,
   KiroProvider = KiroProvider,
   GeminiCLIProvider = GeminiCLIProvider,
+  MistralVibeCLIProvider = MistralVibeCLIProvider,
 }


### PR DESCRIPTION
Adds support to Mistral Vibe CLI provider. Models are non selectable, but works fine with "auto" configuration.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, additive change that introduces a new provider wrapper around an external CLI without altering existing provider behavior.
> 
> **Overview**
> Adds `MistralVibeCLIProvider` to `lua/99/providers.lua`, enabling requests to be executed via the `vibe` CLI using `--agent auto-approve` and `--prompt`.
> 
> Exports the new provider alongside existing ones and sets its default model to `auto` (model selection is not supported).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f4c6c9b374506c575271ff3cf9744c8888a89da3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->