### PR TITLE
fix: qflist filepath on windows

### DIFF
--- a/lua/99/ops/qfix-helpers.lua
+++ b/lua/99/ops/qfix-helpers.lua
@@ -2,7 +2,7 @@ local M = {}
 
 --- @return _99.Search.Result | nil
 function M.parse_line(line)
-  local filepath, lnum_raw, rest = line:match("^(.*):(%d+):(.+)$")
+  local filepath, lnum_raw, rest = line:match("^(.-):(%d+):(.+)$")
   if not filepath or not lnum_raw or not rest then
     return nil
   end

--- a/lua/99/ops/qfix-helpers.lua
+++ b/lua/99/ops/qfix-helpers.lua
@@ -2,12 +2,12 @@ local M = {}
 
 --- @return _99.Search.Result | nil
 function M.parse_line(line)
-  local filepath, lnum_raw, rest = line:match("^(.-):([^:]+):(.+)$")
+  local filepath, lnum_raw, rest = line:match("^(.*):(%d+):(.+)$")
   if not filepath or not lnum_raw or not rest then
     return nil
   end
 
-  local col_raw, _, notes = rest:match("^([^,]+),([^,]+),?(.*)$")
+  local col_raw, _, notes = rest:match("^(%d+),([^,]+),?(.*)$")
   if not col_raw then
     return nil
   end

--- a/lua/99/test/qfix_helpers_spec.lua
+++ b/lua/99/test/qfix_helpers_spec.lua
@@ -17,6 +17,18 @@ describe("qfix helpers", function()
     }, parsed)
   end)
 
+  it("parse_line parses Windows drive-letter paths", function()
+    local parsed =
+      QFixHelpers.parse_line("C:\\repo\\lua\\99\\ops\\search.lua:42:7,3,win path")
+
+    eq({
+      filename = "C:\\repo\\lua\\99\\ops\\search.lua",
+      lnum = 42,
+      col = 7,
+      text = "win path",
+    }, parsed)
+  end)
+
   it("parse_line keeps commas in notes text", function()
     local parsed = QFixHelpers.parse_line("file.lua:10:3,1,note,with,commas")
 


### PR DESCRIPTION
The `parse_line` function in `lua/99/ops/qfix-helpers.lua` splits path/line/column by matching the first `:` separators. On Windows paths like `C:\repo\file.lua:10:3,1,note`, this causes `filename` to become only `C` (drive letter), which breaks quickfix entries.

Edit: just wanted to add some visuals in case anybody was curious what it looks like in Windows:
Before this PR:
<img width="460" height="163" alt="image" src="https://github.com/user-attachments/assets/7da88eee-d94a-4e95-804b-f2c047e2ff4f" />

After this PR:
<img width="1019" height="101" alt="image" src="https://github.com/user-attachments/assets/07823c2c-94db-42b8-af39-9d7881285028" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, well-scoped parsing change with added test coverage; main risk is stricter numeric matching rejecting previously-accepted malformed inputs.
> 
> **Overview**
> Fixes `QFixHelpers.parse_line` to only treat numeric `lnum`/`col` segments as the `:`/`,` separators, preventing Windows drive letters (e.g. `C:\...`) from being mis-parsed as the filename.
> 
> Adds a unit test covering Windows drive-letter paths to ensure quickfix entries are created with the full filepath and correct line/column values.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 11f5152b6423c353af4dcc19285dfee3f4a850fa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->