### PR TITLE
fix: the tests

### DIFF
--- a/lua/99/test/window_spec.lua
+++ b/lua/99/test/window_spec.lua
@@ -27,9 +27,8 @@ describe("Window", function()
         ["<CR>"] = "submit",
       },
     })
-
     eq(2, #Window.active_windows)
-    eq(1, vim.wo[win.win_id].scrolloff)
+    eq(3, vim.wo[win.win_id].scrolloff)
 
     local legend = Window.active_windows[2]
     local lines = vim.api.nvim_buf_get_lines(legend.buf_id, 0, -1, false)


### PR DESCRIPTION
Ain't much, but it's honest work...

Looking at the code it's clear that the intent was for the scrolloff to be 3
comment in window init.lua say ''-- one for the border, one for the extra space, and then keymap count"

keymap is 1, 3 in total...


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only expectation change; no production logic modified, but it may mask a real UI regression if the prior value was intentional.
> 
> **Overview**
> Updates `Window` specs to expect `scrolloff = 3` after `capture_input()` creates the keymap legend, aligning the test with the implementation’s `keyoffset + 2` behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 211e10503dcecb0d9cba416ad1f579e0affe0a30. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->