### PR TITLE
add Claude-specific effort level support

### DIFF
--- a/lua/99/extensions/fzf_lua.lua
+++ b/lua/99/extensions/fzf_lua.lua
@@ -44,6 +44,36 @@ function M.select_model(provider)
   end)
 end
 
+function M.select_effort()
+  local ok, fzf = pcall(require, "fzf-lua")
+  if not ok then
+    vim.notify(
+      "99: fzf-lua is required for this extension",
+      vim.log.levels.ERROR
+    )
+    return
+  end
+
+  local info = pickers_util.get_effort_levels()
+  if not info then
+    return
+  end
+
+  local current = info.current or "none"
+
+  fzf.fzf_exec(promote_current(info.levels, current), {
+    prompt = "99: Select Effort (current: " .. current .. ")> ",
+    actions = {
+      ["enter"] = function(selected)
+        if not selected or #selected == 0 then
+          return
+        end
+        pickers_util.on_effort_selected(selected[1])
+      end,
+    },
+  })
+end
+
 function M.select_provider()
   local ok, fzf = pcall(require, "fzf-lua")
   if not ok then

--- a/lua/99/extensions/pickers.lua
+++ b/lua/99/extensions/pickers.lua
@@ -76,4 +76,24 @@ function M.on_provider_selected(name, lookup)
   )
 end
 
+--- @return { levels: string[], current: string|nil }|nil
+function M.get_effort_levels()
+  local provider = _99.get_provider()
+  local levels = provider._get_effort_levels and provider:_get_effort_levels()
+  if not levels then
+    vim.notify(
+      "99: Current provider does not support effort levels",
+      vim.log.levels.WARN
+    )
+    return nil
+  end
+  return { levels = levels, current = _99.get_effort() }
+end
+
+--- @param level string
+function M.on_effort_selected(level)
+  _99.set_effort(level)
+  vim.notify("99: Effort set to " .. level)
+end
+
 return M

--- a/lua/99/extensions/telescope.lua
+++ b/lua/99/extensions/telescope.lua
@@ -53,6 +53,49 @@ function M.select_model(provider)
   end)
 end
 
+function M.select_effort()
+  local ok, pickers = pcall(require, "telescope.pickers")
+  if not ok then
+    vim.notify(
+      "99: telescope.nvim is required for this extension",
+      vim.log.levels.ERROR
+    )
+    return
+  end
+
+  local finders = require("telescope.finders")
+  local conf = require("telescope.config").values
+  local actions = require("telescope.actions")
+  local action_state = require("telescope.actions.state")
+
+  local info = pickers_util.get_effort_levels()
+  if not info then
+    return
+  end
+
+  local current = info.current or "none"
+
+  pickers
+    .new({}, {
+      prompt_title = "99: Select Effort (current: " .. current .. ")",
+      default_selection_index = index_of(info.levels, current),
+      finder = finders.new_table({ results = info.levels }),
+      sorter = conf.generic_sorter({}),
+      attach_mappings = function(prompt_bufnr)
+        actions.select_default:replace(function()
+          actions.close(prompt_bufnr)
+          local selection = action_state.get_selected_entry()
+          if not selection then
+            return
+          end
+          pickers_util.on_effort_selected(selection[1])
+        end)
+        return true
+      end,
+    })
+    :find()
+end
+
 function M.select_provider()
   local ok, pickers = pcall(require, "telescope.pickers")
   if not ok then

--- a/lua/99/init.lua
+++ b/lua/99/init.lua
@@ -490,6 +490,48 @@ function _99.get_model()
   return _99_state.model
 end
 
+--- @param level string|nil
+--- @return _99
+function _99.set_effort(level)
+  local provider = _99.get_provider()
+  local valid_levels = provider._get_effort_levels
+    and provider:_get_effort_levels()
+  if not valid_levels then
+    vim.notify(
+      "99: Current provider does not support effort levels",
+      vim.log.levels.WARN
+    )
+    return _99
+  end
+  if level ~= nil then
+    local found = false
+    for _, v in ipairs(valid_levels) do
+      if v == level then
+        found = true
+        break
+      end
+    end
+    if not found then
+      vim.notify(
+        "99: Invalid effort level: "
+          .. tostring(level)
+          .. ". Valid levels: "
+          .. table.concat(valid_levels, ", "),
+        vim.log.levels.ERROR
+      )
+      return _99
+    end
+  end
+  provider.effort = level
+  return _99
+end
+
+--- @return string|nil
+function _99.get_effort()
+  local provider = _99.get_provider()
+  return provider.effort
+end
+
 --- @return _99.Providers.BaseProvider
 function _99.get_provider()
   return _99_state.provider_override or Providers.OpenCodeProvider

--- a/lua/99/providers.lua
+++ b/lua/99/providers.lua
@@ -28,6 +28,11 @@ function BaseProvider.fetch_models(callback)
   callback(nil, "This provider does not support listing models")
 end
 
+--- @return string[]|nil
+function BaseProvider._get_effort_levels()
+  return nil
+end
+
 --- @param context _99.Prompt
 function BaseProvider:_retrieve_response(context)
   local logger = context.logger:set_area(self:_get_provider_name())
@@ -182,18 +187,28 @@ end
 --- @class ClaudeCodeProvider : _99.Providers.BaseProvider
 local ClaudeCodeProvider = setmetatable({}, { __index = BaseProvider })
 
+--- @return string[]
+function ClaudeCodeProvider._get_effort_levels()
+  return { "low", "medium", "high", "max" }
+end
+
 --- @param query string
 --- @param context _99.Prompt
 --- @return string[]
-function ClaudeCodeProvider._build_command(_, query, context)
-  return {
+function ClaudeCodeProvider._build_command(self, query, context)
+  local cmd = {
     "claude",
     "--dangerously-skip-permissions",
     "--model",
     context.model,
-    "--print",
-    query,
   }
+  if self.effort then
+    table.insert(cmd, "--effort")
+    table.insert(cmd, self.effort)
+  end
+  table.insert(cmd, "--print")
+  table.insert(cmd, query)
+  return cmd
 end
 
 --- @return string

--- a/lua/99/test/providers_spec.lua
+++ b/lua/99/test/providers_spec.lua
@@ -31,7 +31,7 @@ describe("providers", function()
     it("builds correct command with model", function()
       local request = { model = "anthropic/claude-sonnet-4-5" }
       local cmd =
-        Providers.ClaudeCodeProvider._build_command(nil, "test query", request)
+        Providers.ClaudeCodeProvider._build_command({}, "test query", request)
       eq({
         "claude",
         "--dangerously-skip-permissions",
@@ -42,8 +42,43 @@ describe("providers", function()
       }, cmd)
     end)
 
+    it("builds command without effort flag when effort is not set", function()
+      local request = { model = "claude-sonnet-4-5" }
+      local cmd =
+        Providers.ClaudeCodeProvider._build_command({}, "test query", request)
+      for _, v in ipairs(cmd) do
+        assert.is_not.equal("--effort", v)
+      end
+    end)
+
+    it("builds command with effort flag when effort is set", function()
+      local request = { model = "claude-sonnet-4-5" }
+      local cmd = Providers.ClaudeCodeProvider._build_command(
+        { effort = "high" },
+        "test query",
+        request
+      )
+      eq({
+        "claude",
+        "--dangerously-skip-permissions",
+        "--model",
+        "claude-sonnet-4-5",
+        "--effort",
+        "high",
+        "--print",
+        "test query",
+      }, cmd)
+    end)
+
     it("has correct default model", function()
       eq("claude-sonnet-4-5", Providers.ClaudeCodeProvider._get_default_model())
+    end)
+
+    it("returns effort levels", function()
+      eq(
+        { "low", "medium", "high", "max" },
+        Providers.ClaudeCodeProvider:_get_effort_levels()
+      )
     end)
   end)
 
@@ -158,6 +193,13 @@ describe("providers", function()
       eq("function", type(Providers.ClaudeCodeProvider.make_request))
       eq("function", type(Providers.CursorAgentProvider.make_request))
       eq("function", type(Providers.GeminiCLIProvider.make_request))
+    end)
+
+    it("_get_effort_levels returns nil for non-Claude providers", function()
+      eq(nil, Providers.OpenCodeProvider:_get_effort_levels())
+      eq(nil, Providers.CursorAgentProvider:_get_effort_levels())
+      eq(nil, Providers.GeminiCLIProvider:_get_effort_levels())
+      eq(nil, Providers.KiroProvider:_get_effort_levels())
     end)
   end)
 end)


### PR DESCRIPTION
## Summary
- Add `_get_effort_levels()` to BaseProvider (nil) and ClaudeCodeProvider (`low`, `medium`, `high`, `max`)
- Add `set_effort`/`get_effort` public API with runtime validation
- Add `select_effort()` pickers for both telescope and fzf-lua
- Add tests for effort in `_build_command` and `_get_effort_levels`

## Test plan
- [x] `make pr_ready` passes (lint, tests, format)
- [ ] `_99.set_effort("high")` then trigger search — verify `--effort high` in command
- [ ] `_99.set_effort("foo")` — verify error notification
- [ ] `_99.set_effort(nil)` — verify effort cleared
- [ ] Switch to non-Claude provider, call `set_effort` — verify warning

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk: changes provider request command construction and adds new public API state (`set_effort`/`get_effort`) that can affect execution for Claude runs; other providers are guarded to warn/ignore.
> 
> **Overview**
> Adds Claude-specific “effort level” support end-to-end: a new provider hook `BaseProvider._get_effort_levels()` (default `nil`) and `ClaudeCodeProvider._get_effort_levels()` (`low|medium|high|max`), plus `_99.set_effort()`/`_99.get_effort()` with runtime validation and provider capability warnings.
> 
> Updates `ClaudeCodeProvider._build_command()` to optionally append `--effort <level>` when set, and introduces `select_effort()` pickers for both `telescope.nvim` and `fzf-lua` to let users choose effort interactively. Tests are expanded to cover effort flag inclusion/exclusion and the default `nil` behavior for non-Claude providers.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c8168ecd54556417797ffee5ec110d0a53f2a90e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->