### PR TITLE
default insert mode for the overlay

### DIFF
--- a/lua/99/window/init.lua
+++ b/lua/99/window/init.lua
@@ -546,6 +546,8 @@ function M.capture_input(name, opts)
     )
   end
 
+  vim.cmd("startinsert")
+
   return win
 end
 


### PR DESCRIPTION
opens the overlay in insert mode by default so you can start typing right away.