### PR TITLE
fix: disable OpenCode title generation to improve latency

### DIFF
--- a/lua/99/providers.lua
+++ b/lua/99/providers.lua
@@ -156,6 +156,8 @@ function OpenCodeProvider._build_command(_, query, context)
     "build",
     "-m",
     context.model,
+    "--title",
+    "",
     query,
   }
 end

--- a/lua/99/test/providers_spec.lua
+++ b/lua/99/test/providers_spec.lua
@@ -15,6 +15,8 @@ describe("providers", function()
         "build",
         "-m",
         "anthropic/claude-sonnet-4-5",
+        "--title",
+        "",
         "test query",
       }, cmd)
     end)


### PR DESCRIPTION
Before processing the user prompt, OpenCode prompts the LLM to generate a session title for display in the UI.

<img width="1674" height="980" alt="title" src="https://github.com/user-attachments/assets/d14b72e3-032d-4615-a9b7-c67dd5c0e036" />

While the token count isn't much, the additional latency of this request will definitely makes the completion less snappy!

To bypass this, we set the title to an empty string when initializing the OpenCode agent.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new provider path that can generate custom prompts and may edit files directly, plus changes the OpenCode command invocation; issues here could affect request execution and buffer state for multiple providers.
> 
> **Overview**
> Improves provider extensibility by letting providers optionally implement `_build_prompt`, which `Prompt:start_request` now uses to generate the request text instead of always concatenating `agent_context`.
> 
> Disables OpenCode’s session-title generation by passing `--title ""` in `OpenCodeProvider._build_command` (to reduce extra latency), and adds a new `PiProvider` that formats a file-editing prompt with line-numbered visual snippets, supports `pi --list-models`, and triggers a `checktime` buffer reload after successful visual edits for providers that edit files directly. Tests are updated/added to cover the new command args and `PiProvider` behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 78fba903d39368a2cf7542e2cf64d28a42c28391. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->