### PR TITLE
feat: continue last command

### DIFF
--- a/lua/99/extensions/files/init.lua
+++ b/lua/99/extensions/files/init.lua
@@ -171,26 +171,25 @@ function M.discover_files()
       local full_path = dir .. "/" .. name
       local rel_path = get_relative_path(full_path, root)
 
-      if matches_exclude_pattern(name) or matches_exclude_pattern(rel_path) then
-        goto continue
-      end
+      if
+        not matches_exclude_pattern(name)
+        and not matches_exclude_pattern(rel_path)
+      then
+        if type == "directory" then
+          scan_dir(full_path)
+        elseif type == "file" then
+          table.insert(files, {
+            path = rel_path,
+            name = name,
+            absolute_path = full_path,
+          })
+          count = count + 1
 
-      if type == "directory" then
-        scan_dir(full_path)
-      elseif type == "file" then
-        table.insert(files, {
-          path = rel_path,
-          name = name,
-          absolute_path = full_path,
-        })
-        count = count + 1
-
-        if count >= config.max_files then
-          break
+          if count >= config.max_files then
+            break
+          end
         end
       end
-
-      ::continue::
     end
   end
 

--- a/lua/99/init.lua
+++ b/lua/99/init.lua
@@ -202,6 +202,8 @@ local _99_state
 --- @field visual fun(opts: _99.ops.Opts): _99.TraceID
 --- takes your current selection and sends that along with the prompt provided and replaces
 --- your visual selection with the results
+--- @field continue fun(opts: _99.ops.ContinueOpts?): _99.TraceID | nil
+--- continues a previous successful 99 request by sending prior turns plus a follow-up prompt
 --- @field view_logs fun(): nil
 --- view_logs allows you to select the request you want to see and then you
 --- get to see the logs.
@@ -219,6 +221,19 @@ local _99 = {
   ERROR = Level.ERROR,
   FATAL = Level.FATAL,
 }
+
+--- @param opts _99.ops.Opts
+--- @param response string
+--- @return _99.ops.Opts
+local function apply_captured_prompt_opts(opts, response)
+  local rules_and_names = Agents.by_name(_99_state.rules, response)
+  opts.additional_rules = opts.additional_rules or {}
+  for _, r in ipairs(rules_and_names.rules) do
+    table.insert(opts.additional_rules, r)
+  end
+  opts.additional_prompt = response
+  return opts
+end
 
 --- @param cb fun(context: _99.Prompt, o: _99.ops.Opts?): nil
 --- @param name string
@@ -245,14 +260,38 @@ local function capture_prompt(cb, name, context, opts, capture_content)
       if not ok then
         return
       end
-      local rules_and_names = Agents.by_name(_99_state.rules, response)
-      opts.additional_rules = opts.additional_rules or {}
-      for _, r in ipairs(rules_and_names.rules) do
-        table.insert(opts.additional_rules, r)
-      end
-      opts.additional_prompt = response
+      opts = apply_captured_prompt_opts(opts, response)
       context.user_prompt = response
       cb(context, opts)
+    end,
+    on_load = function()
+      Extensions.setup_buffer(_99_state)
+    end,
+    rules = _99_state.rules,
+  })
+end
+
+--- @param cb fun(o: _99.ops.Opts?): nil
+--- @param name string
+--- @param logger _99.Logger
+--- @param opts _99.ops.Opts
+--- @param capture_content string[] | nil
+local function capture_prompt_opts(cb, name, logger, opts, capture_content)
+  Window.capture_input(name, {
+    keymap = {
+      [":w"] = "submit",
+    },
+    content = capture_content,
+
+    --- @param ok boolean
+    --- @param response string
+    cb = function(ok, response)
+      logger:debug("capture_prompt", "success", ok, "response", response)
+      if not ok then
+        return
+      end
+      opts = apply_captured_prompt_opts(opts, response)
+      cb(opts)
     end,
     on_load = function()
       Extensions.setup_buffer(_99_state)
@@ -312,6 +351,52 @@ function _99.open()
       _99.open_tutorial(r)
     end
   end)
+end
+
+--- @param opts? _99.ops.ContinueOpts
+--- @return _99.TraceID | nil
+function _99.continue(opts)
+  local o = process_opts(opts or {}) --[[@as _99.ops.ContinueOpts]]
+  local source
+
+  if o.last then
+    source = _99_state.tracking:latest_successful(o.type)
+  else
+    local requests = _99_state.tracking:successful()
+    local str_requests = Tracking.to_selectable_list(requests)
+    select_window(str_requests, function(idx)
+      local selected = requests[idx]
+      if not selected then
+        return
+      end
+      if o.additional_prompt then
+        ops.continue_chat.run(_99_state, ops, selected, o)
+      else
+        capture_prompt_opts(function(captured_opts)
+          ops.continue_chat.run(_99_state, ops, selected, captured_opts)
+        end, "Continue", selected.logger, o)
+      end
+    end)
+    return nil
+  end
+
+  if not source then
+    vim.notify(
+      "No successful 99 request found to continue",
+      vim.log.levels.WARN
+    )
+    return nil
+  end
+
+  if o.additional_prompt then
+    return ops.continue_chat.run(_99_state, ops, source, o)
+  end
+
+  capture_prompt_opts(function(captured_opts)
+    ops.continue_chat.run(_99_state, ops, source, captured_opts)
+  end, "Continue", source.logger, o)
+
+  return nil
 end
 
 --- @param opts? _99.ops.Opts

--- a/lua/99/ops/continue.lua
+++ b/lua/99/ops/continue.lua
@@ -1,0 +1,129 @@
+local Prompt = require("99.prompt")
+
+local M = {}
+
+--- Default number of recent turns to include in continuation prompt
+local DEFAULT_CONTINUE_HISTORY_LIMIT = 3
+
+--- Mapping of supported operations to their context creators and dispatch functions
+--- @type table<
+---   _99.Prompt.Operation,
+---   {create: fun(state: _99.State): _99.Prompt, dispatch: fun(ops: table, context: _99.Prompt, opts: table): nil}
+--- >
+local OPERATION_MAP = {
+  vibe = {
+    create = function(state)
+      return Prompt.vibe(state)
+    end,
+    dispatch = function(ops, context, opts)
+      ops.vibe(context, opts)
+    end,
+  },
+  search = {
+    create = function(state)
+      return Prompt.search(state)
+    end,
+    dispatch = function(ops, context, opts)
+      ops.search(context, opts)
+    end,
+  },
+  tutorial = {
+    create = function(state)
+      return Prompt.tutorial(state)
+    end,
+    dispatch = function(ops, context, opts)
+      ops.tutorial(context, opts)
+    end,
+  },
+  visual = {
+    create = function(state)
+      return Prompt.visual(state)
+    end,
+    dispatch = function(ops, context, opts)
+      ops.over_range(context, opts)
+    end,
+  },
+}
+
+--- @param state _99.State
+--- @param source _99.Prompt
+--- @param follow_up string
+--- @param op_config table
+--- @return _99.Prompt
+local function create_context_for_source(state, source, follow_up, op_config)
+  local context = op_config.create(state)
+  context.session_id = source.session_id
+  context.turns = vim.deepcopy(source.turns or {})
+  context.user_prompt = follow_up
+  return context
+end
+
+--- @param state _99.State
+--- @param source _99.Prompt
+--- @param follow_up string
+--- @return string
+local function build_follow_up_prompt(state, source, follow_up)
+  local turns = source:recent_turns(DEFAULT_CONTINUE_HISTORY_LIMIT)
+  return state.prompts.prompts.continue_chat(source.operation, turns, follow_up)
+end
+
+--- @param state _99.State
+--- @param ops table
+--- @param source _99.Prompt
+--- @param opts _99.ops.ContinueOpts
+--- @return _99.TraceID | nil
+function M.run(state, ops, source, opts)
+  if not source then
+    vim.notify("99.continue requires a source prompt", vim.log.levels.WARN)
+    return nil
+  end
+
+  opts = opts or {}
+  local follow_up = opts.additional_prompt
+  if not follow_up or follow_up == "" then
+    vim.notify("99.continue requires a follow-up prompt", vim.log.levels.WARN)
+    return nil
+  end
+
+  if not source.turns or #source.turns == 0 then
+    vim.notify(
+      "99.continue could not find conversation turns",
+      vim.log.levels.WARN
+    )
+    return nil
+  end
+
+  -- Visual continuation requires a fresh visual selection
+  if source.operation == "visual" then
+    local mode = vim.fn.mode()
+    if mode ~= "v" and mode ~= "V" and mode ~= "\22" then
+      vim.notify(
+        "99.continue visual requests require a fresh visual selection",
+        vim.log.levels.WARN
+      )
+      return nil
+    end
+  end
+
+  local op_config = OPERATION_MAP[source.operation]
+  if not op_config then
+    vim.notify(
+      "99.continue does not support operation: " .. tostring(source.operation),
+      vim.log.levels.WARN
+    )
+    return nil
+  end
+
+  local context = create_context_for_source(state, source, follow_up, op_config)
+
+  local continuation_prompt = build_follow_up_prompt(state, source, follow_up)
+  local continued_opts = vim.tbl_extend("force", opts, {
+    additional_prompt = continuation_prompt,
+  })
+
+  op_config.dispatch(ops, context, continued_opts)
+
+  return context.xid
+end
+
+return M

--- a/lua/99/ops/init.lua
+++ b/lua/99/ops/init.lua
@@ -1,5 +1,5 @@
 --- @class _99.ops.Opts
---- The options that are used throughout all the interations with 99.  This
+--- The options that are used throughout all the interactions with 99.  This
 --- includes search, visual, and others
 ---
 --- @docs included
@@ -31,9 +31,17 @@
 --- There are no properties yet.  But i would like to tweek some behavior based on opts
 --- @docs included
 
+--- @class _99.ops.ContinueOpts : _99.ops.Opts
+--- Options for continuing a previous 99 request.
+---
+--- @field last? boolean If true, continue the latest successful request
+--- @field type? _99.Prompt.Operation Filter to latest of this type ("vibe", "search", "tutorial", "visual")
+--- @docs included
+
 return {
   search = require("99.ops.search"),
   tutorial = require("99.ops.tutorial"),
   over_range = require("99.ops.over-range"),
   vibe = require("99.ops.vibe"),
+  continue_chat = require("99.ops.continue"),
 }

--- a/lua/99/ops/over-range.lua
+++ b/lua/99/ops/over-range.lua
@@ -88,6 +88,7 @@ local function over_range(context, opts)
         table.insert(lines, 1, "")
 
         new_range:replace_text(lines)
+        context:append_turn(context.user_prompt, response)
         context._99:sync()
       end
     end,

--- a/lua/99/ops/qfix-helpers.lua
+++ b/lua/99/ops/qfix-helpers.lua
@@ -1,5 +1,37 @@
 local M = {}
 
+--- Normalize absolute paths to handle symlinks (e.g., /tmp -> /private/tmp on macOS).
+--- Relative paths are preserved as-is.
+--- @param filepath string
+--- @return string normalized path
+local function normalize_path(filepath)
+  -- Only normalize absolute paths
+  if not filepath:match("^/") then
+    return filepath
+  end
+
+  -- Extract parent directory and basename
+  local parent = filepath:match("^(.+)/[^/]+$")
+  local basename = filepath:match("[^/]+$")
+
+  if not parent or not basename then
+    return filepath
+  end
+
+  -- Get realpath of parent directory
+  local ok, real_parent = pcall(vim.fn.resolve, parent)
+  if not ok or not real_parent or real_parent == "" then
+    return filepath
+  end
+
+  -- If parent resolved differently, reconstruct path
+  if real_parent ~= parent then
+    return real_parent .. "/" .. basename
+  end
+
+  return filepath
+end
+
 --- @return _99.Search.Result | nil
 function M.parse_line(line)
   local filepath, lnum_raw, rest = line:match("^(.-):([^:]+):(.+)$")
@@ -16,7 +48,7 @@ function M.parse_line(line)
   local col = tonumber(col_raw) or 1
 
   return {
-    filename = filepath,
+    filename = normalize_path(filepath),
     lnum = lnum,
     col = col,
     text = notes or "",

--- a/lua/99/ops/search.lua
+++ b/lua/99/ops/search.lua
@@ -9,11 +9,10 @@ local make_observer = CleanUp.make_observer
 local function create_search_locations(context, response)
   local qf_list = QFixHelpers.create_qfix_entries(response)
   context.logger:set_area("search"):debug("qf_list created", "qf_list", qf_list)
-  context.data = {
-    type = "search",
-    qfix_items = qf_list,
-    response = response,
-  }
+  --- Mutate existing data table to preserve table identity
+  context.data.type = "search"
+  context.data.qfix_items = qf_list
+  context.data.response = response
 
   if #qf_list > 0 then
     require("99").open_qfix_for_request(context)
@@ -53,6 +52,7 @@ local function search(context, opts)
       )
     elseif status == "success" then
       create_search_locations(context, response)
+      context:append_turn(context.user_prompt, response)
       context._99:sync()
     end
   end))

--- a/lua/99/ops/tutorial.lua
+++ b/lua/99/ops/tutorial.lua
@@ -48,6 +48,7 @@ local function tutorial(context, opts)
       )
     elseif status == "success" then
       open_tutorial(context, response)
+      context:append_turn(context.user_prompt, response)
       context._99:sync()
     end
   end))

--- a/lua/99/ops/vibe.lua
+++ b/lua/99/ops/vibe.lua
@@ -9,11 +9,10 @@ local make_observer = CleanUp.make_observer
 local function finish_vibe(context, response)
   local qf_list = QFixHelpers.create_qfix_entries(response)
   context.logger:set_area("vibe"):debug("qf_list created", "qf_list", qf_list)
-  context.data = {
-    type = "vibe",
-    qfix_items = qf_list,
-    response = response,
-  }
+  --- Mutate existing data table to preserve table identity
+  context.data.type = "vibe"
+  context.data.qfix_items = qf_list
+  context.data.response = response
 
   if #qf_list > 0 then
     require("99").open_qfix_for_request(context)
@@ -50,15 +49,16 @@ local function vibe(context, opts)
   --- i think an interface, CleanUpI could be something that is worth it :)
   context:start_request(make_observer(context, function(status, response)
     if status == "cancelled" then
-      logger:debug("request cancelled for search")
+      logger:debug("request cancelled for vibe")
     elseif status == "failed" then
       logger:error(
-        "request failed for search",
+        "request failed for vibe",
         "error response",
         response or "no response provided"
       )
     elseif status == "success" then
       finish_vibe(context, response)
+      context:append_turn(context.user_prompt, response)
       context._99:sync()
     end
   end))

--- a/lua/99/prompt-settings.lua
+++ b/lua/99/prompt-settings.lua
@@ -165,6 +165,46 @@ Previous contents, which may not exist, can be written over without worry
 After writing TEMP_FILE once you should be done.  Be done and end the session.
 ]]
   end,
+  --- @param operation _99.Prompt.Operation
+  --- @param turns _99.Prompt.Turn[]
+  --- @param follow_up string
+  --- @return string
+  continue_chat = function(operation, turns, follow_up)
+    local lines = {
+      string.format("You are continuing a previous 99.%s request.", operation),
+      "",
+      "Conversation so far:",
+      "",
+    }
+
+    for _, turn in ipairs(turns) do
+      table.insert(lines, "User:")
+      table.insert(lines, turn.user_prompt)
+      table.insert(lines, "")
+      table.insert(lines, "Assistant:")
+      table.insert(lines, turn.response)
+      table.insert(lines, "")
+    end
+
+    table.insert(lines, "New follow-up:")
+    table.insert(lines, follow_up)
+    table.insert(lines, "")
+    table.insert(
+      lines,
+      string.format(
+        "Continue by refining the previous result. Preserve the output format expected by 99.%s.",
+        operation
+      )
+    )
+    table.insert(lines, "")
+    table.insert(
+      lines,
+      "IMPORTANT: Your response MUST be written to TEMP_FILE and not provided conversationally. "
+        .. "Do not output explanatory text; only write the result to TEMP_FILE."
+    )
+
+    return table.concat(lines, "\n")
+  end,
 }
 
 --- @class _99.Prompts

--- a/lua/99/prompt.lua
+++ b/lua/99/prompt.lua
@@ -28,9 +28,17 @@ local filetype_map = {
 --- @alias _99.Prompt.State "ready" | "requesting" | _99.Prompt.EndingState
 --- @alias _99.Prompt.Cleanup fun(): nil
 
+--- @class _99.Prompt.Turn
+--- @field user_prompt string
+--- @field response string
+
 --- @class _99.Prompt.Serialized
 --- @field data _99.Prompt.Data
 --- @field user_prompt string
+--- @field session_id string
+--- @field turns _99.Prompt.Turn[]
+--- @field started_at number | nil
+--- @field completed_at number | nil
 --- @class _99.Prompt.Data.Search
 --- @field type "search"
 --- @field qfix_items _99.Search.Result[]
@@ -62,6 +70,7 @@ local filetype_map = {
 --- @field state _99.Prompt.State
 --- @field full_path string
 --- @field started_at number
+--- @field completed_at number | nil
 --- @field data _99.Prompt.Data
 --- @field agent_context string[]
 --- @field tmp_file string
@@ -70,6 +79,8 @@ local filetype_map = {
 --- @field xid number
 --- @field clean_ups (fun(): nil)[]
 --- @field _99 _99.State
+--- @field session_id string
+--- @field turns _99.Prompt.Turn[]
 ---@diagnostic disable-next-line: undefined-doc-name
 --- @field _proc vim.SystemObj?
 local Prompt = {}
@@ -100,6 +111,8 @@ local function set_defaults(context, _99)
   context.full_path = full_path
   context.marks = {}
   context.started_at = Time.now()
+  context.session_id = tostring(get_id())
+  context.turns = {}
 end
 
 --- TODO: Work item for "TODO implementation"
@@ -112,18 +125,42 @@ end
 --- @param data _99.Prompt.Serialized
 --- @return _99.Prompt
 function Prompt.deserialize(_99, data)
-  local prompt = setmetatable({
-    _99 = _99,
-    data = data.data,
-    operation = data.data.type,
-    user_prompt = data.user_prompt,
-    started_at = Time.now(),
+  --- Create context and initialize with set_defaults for all runtime fields
+  local context = {}
+  set_defaults(context, _99)
 
-    --- we should only sync successful requests
-    state = "success",
+  local session_id = data.session_id or context.session_id
+  local turns = data.turns
 
-    xid = get_id(),
-  }, Prompt)
+  --- Lazy-normalize old serialized data without turns into a one-turn session
+  if not turns then
+    turns = {}
+    local response = ""
+    if data.data.type == "tutorial" and data.data.tutorial then
+      response = table.concat(data.data.tutorial, "\n")
+    elseif data.data.response then
+      response = data.data.response
+    end
+    table.insert(turns, {
+      user_prompt = data.user_prompt,
+      response = response,
+    })
+  end
+
+  --- Override defaults with deserialized data while preserving runtime fields
+  context.data = data.data
+  context.operation = data.data.type
+  context.user_prompt = data.user_prompt
+  --- Preserve persisted ordering data. Old serialized prompts did not include
+  --- timestamps, so keep the runtime started_at default and leave completed_at
+  --- nil; tracking falls back to started_at when completed_at is unavailable.
+  context.started_at = data.started_at or context.started_at
+  context.completed_at = data.completed_at
+  context.state = "success"
+  context.session_id = session_id
+  context.turns = copy(turns)
+
+  local prompt = setmetatable(context, Prompt)
   assert(prompt:valid(), "prompt is not valid from data")
   return prompt
 end
@@ -134,7 +171,34 @@ function Prompt:serialize()
   return {
     data = self.data,
     user_prompt = self.user_prompt,
+    session_id = self.session_id,
+    turns = copy(self.turns),
+    started_at = self.started_at,
+    completed_at = self.completed_at,
   }
+end
+
+--- @param user_prompt string
+--- @param response string
+function Prompt:append_turn(user_prompt, response)
+  table.insert(self.turns, {
+    user_prompt = user_prompt,
+    response = response,
+  })
+end
+
+--- @param max number
+--- @return _99.Prompt.Turn[]
+function Prompt:recent_turns(max)
+  if max <= 0 then
+    return {}
+  end
+  local result = {}
+  local start_idx = math.max(1, #self.turns - max + 1)
+  for i = start_idx, #self.turns do
+    table.insert(result, copy(self.turns[i]))
+  end
+  return result
 end
 
 --- @param _99 _99.State
@@ -246,6 +310,7 @@ function Prompt:_observer(obs)
       end
     end,
     on_complete = function(status, res)
+      self.completed_at = Time.now()
       self.state = status
       if obs then
         obs.on_complete(status, res)
@@ -323,6 +388,7 @@ function Prompt:cancel()
     return
   end
 
+  self.completed_at = Time.now()
   self.state = "cancelled"
   local proc = self._proc
   ---@diagnostic disable-next-line: undefined-field

--- a/lua/99/providers.lua
+++ b/lua/99/providers.lua
@@ -70,6 +70,10 @@ function BaseProvider:make_request(query, context, observer)
     end
   )
 
+  -- Tutorial fallback may need stdout when TEMP_FILE is blank; other operations
+  -- keep streaming stdout to observers without retaining it in memory.
+  local stdout_accumulator = {}
+
   local command = self:_build_command(query, context)
   local extra_args = context._99 and context._99.provider_extra_args or {}
   if #extra_args > 0 then
@@ -91,6 +95,11 @@ function BaseProvider:make_request(query, context, observer)
           logger:debug("stdout#error", "err", err)
         end
         if not err and data then
+          if context.operation == "tutorial" then
+            -- Provider stdout can include progress/logging, so only retain it for
+            -- the tutorial-only fallback path that runs when TEMP_FILE is blank.
+            table.insert(stdout_accumulator, data)
+          end
           observer.on_stdout(data)
         end
       end),
@@ -127,6 +136,23 @@ function BaseProvider:make_request(query, context, observer)
         vim.schedule(function()
           local ok, res = self:_retrieve_response(context)
           if ok then
+            -- For tutorial operation: if temp file is empty but stdout has content, use stdout
+            if
+              vim.trim(res) == ""
+              and context.operation == "tutorial"
+              and #stdout_accumulator > 0
+            then
+              local stdout_content = table.concat(stdout_accumulator)
+              if vim.trim(stdout_content) ~= "" then
+                logger:debug(
+                  "using stdout fallback for empty temp file",
+                  "operation",
+                  context.operation
+                )
+                once_complete("success", stdout_content)
+                return
+              end
+            end
             once_complete("success", res)
           else
             once_complete(

--- a/lua/99/state/tracking.lua
+++ b/lua/99/state/tracking.lua
@@ -36,7 +36,11 @@ function Tracking.new(_99, previous_state)
     return tracking
   end
 
-  for _, d in ipairs(previous_state.requests or {}) do
+  local serialized_requests = previous_state.requests or {}
+  -- Serialized requests are newest-first for display/storage limits; history is
+  -- oldest-first so reverse scans and index tie-breaks remain deterministic.
+  for i = #serialized_requests, 1, -1 do
+    local d = serialized_requests[i]
     local prompt = Prompt.deserialize(_99, d)
     table.insert(tracking.history, prompt)
     tracking.id_to_request[prompt.xid] = prompt
@@ -56,7 +60,7 @@ end
 function Tracking:completed()
   local count = 0
   for _, entry in ipairs(self.history) do
-    if entry.state ~= "requesting" then
+    if entry:is_completed() or entry:is_cancelled() then
       count = count + 1
     end
   end
@@ -84,7 +88,7 @@ end
 --- @return _99.Prompt[]
 function Tracking:active()
   local out = {}
-  for _, r in pairs(self.history) do
+  for _, r in ipairs(self.history) do
     if r.state == "requesting" then
       table.insert(out, r)
     end
@@ -94,7 +98,7 @@ end
 
 function Tracking:active_count()
   local count = 0
-  for _, r in pairs(self.history) do
+  for _, r in ipairs(self.history) do
     if r.state == "requesting" then
       count = count + 1
     end
@@ -102,7 +106,7 @@ function Tracking:active_count()
   return count
 end
 
---- @param type "search" | "visual" | "tutorial"
+--- @param type "search" | "visual" | "tutorial" | "vibe"
 --- @return _99.Prompt[]
 function Tracking:request_by_type(type)
   local out = {} --[[ @as _99.Prompt[] ]]
@@ -126,25 +130,105 @@ function Tracking:successful()
   return requests
 end
 
+--- @param prompt _99.Prompt
+--- @return number
+local function order_value(prompt)
+  return prompt.completed_at or prompt.started_at or 0
+end
+
+--- @param candidate _99.Prompt
+--- @param candidate_index number
+--- @param current _99.Prompt | nil
+--- @param current_index number
+--- @return boolean
+local function is_newer(candidate, candidate_index, current, current_index)
+  if not current then
+    return true
+  end
+
+  local candidate_value = order_value(candidate)
+  local current_value = order_value(current)
+  if candidate_value ~= current_value then
+    return candidate_value > current_value
+  end
+
+  return candidate_index > current_index
+end
+
+--- Helper to sort newest first while preserving history index as a tie breaker.
+--- @param history_index_by_request table<_99.Prompt, number>
+--- @return fun(a: _99.Prompt, b: _99.Prompt): boolean
+local function newest_first(history_index_by_request)
+  return function(a, b)
+    local a_value = order_value(a)
+    local b_value = order_value(b)
+    if a_value ~= b_value then
+      return a_value > b_value
+    end
+
+    return (history_index_by_request[a] or 0)
+      > (history_index_by_request[b] or 0)
+  end
+end
+
+--- @param type _99.Prompt.Operation | nil
+--- @return _99.Prompt | nil
+function Tracking:latest_successful(type)
+  local latest = nil
+  local latest_index = 0
+
+  for i, request in ipairs(self.history) do
+    if
+      request.state == "success" and (not type or request.operation == type)
+    then
+      if is_newer(request, i, latest, latest_index) then
+        latest = request
+        latest_index = i
+      end
+    end
+  end
+
+  return latest
+end
+
 --- @return _99.State.Tracking.Serialized
 function Tracking:serialize()
   local sc = Tracking.__config.serialize_count
 
+  -- First, dedupe by session_id, keeping only the newest prompt per session
+  -- Use completion time (completed_at or started_at) for determining "newest"
+  --- @type table<string, _99.Prompt>
+  local latest_by_session_id = {}
+  --- @type table<_99.Prompt, number>
+  local history_index_by_request = {}
+  for i, r in ipairs(self.history) do
+    history_index_by_request[r] = i
+    if r.state == "success" then
+      local session_id = r.session_id or tostring(r.xid)
+      local existing = latest_by_session_id[session_id]
+      local existing_index = existing and history_index_by_request[existing]
+        or 0
+      if is_newer(r, i, existing, existing_index) then
+        latest_by_session_id[session_id] = r
+      end
+    end
+  end
+
   --- @type table<_99.Prompt.Operation, _99.Prompt[]>
   local all_requests = {}
-  for _, r in ipairs(self.history) do
+  for _, r in pairs(latest_by_session_id) do
     local op = r.operation
-    all_requests[op] = all_requests[op] or {}
-    if r.state == "success" and sc[op] > 0 then
+    local max = sc[op] or 0
+    if max > 0 then
+      all_requests[op] = all_requests[op] or {}
       table.insert(all_requests[op], r)
     end
   end
+
   for op, _ in pairs(sc) do
     all_requests[op] = all_requests[op] or {}
     local r = all_requests[op]
-    table.sort(r, function(a, b)
-      return a.started_at > b.started_at
-    end)
+    table.sort(r, newest_first(history_index_by_request))
   end
 
   --- @type _99.Prompt[]
@@ -160,9 +244,7 @@ function Tracking:serialize()
     end
   end
 
-  table.sort(requests, function(a, b)
-    return a.started_at > b.started_at
-  end)
+  table.sort(requests, newest_first(history_index_by_request))
   local serialized = {}
   for _, r in ipairs(requests) do
     table.insert(serialized, r:serialize())
@@ -187,14 +269,19 @@ function Tracking.setup(opts)
   local config = Tracking.__config
   local opts_sa = opts.serialize_counts
   if opts_sa then
-    --- note to Agents: in lua 0 or 1 will result in 0.  or only operates on nil or false
-    --- note to prime: i hate llms sometimes... like seriously.. know the language ya dork
-    --- so opts_sa.vibe or sa.vibe if opts_sa.vibe = 0, will yield 0. this is how lua works
     local sa = config.serialize_count
-    sa.vibe = opts_sa.vibe or sa.vibe
-    sa.search = opts_sa.search or sa.search
-    sa.tutorial = opts_sa.tutorial or sa.tutorial
-    sa.visual = opts_sa.visual or sa.visual
+    if opts_sa.vibe ~= nil then
+      sa.vibe = opts_sa.vibe
+    end
+    if opts_sa.search ~= nil then
+      sa.search = opts_sa.search
+    end
+    if opts_sa.tutorial ~= nil then
+      sa.tutorial = opts_sa.tutorial
+    end
+    if opts_sa.visual ~= nil then
+      sa.visual = opts_sa.visual
+    end
   end
 end
 

--- a/lua/99/test/continue_spec.lua
+++ b/lua/99/test/continue_spec.lua
@@ -1,0 +1,608 @@
+-- luacheck: globals describe it assert
+local _99 = require("99")
+local test_utils = require("99.test.test_utils")
+local continue_module = require("99.ops.continue")
+local Prompt = require("99.prompt")
+local Window = require("99.window")
+local eq = assert.are.same
+
+describe("continue operation", function()
+  after_each(function()
+    test_utils.clean_files()
+    -- Ensure we exit visual mode after each test
+    vim.api.nvim_feedkeys(
+      vim.api.nvim_replace_termcodes("<Esc>", true, false, true),
+      "n",
+      false
+    )
+  end)
+
+  --- Helper to create a source prompt with turns for testing
+  --- @param operation "vibe" | "search" | "tutorial" | "visual"
+  --- @param turns table[] Array of {user_prompt, response} tables
+  --- @return _99.Prompt
+  local function create_source_with_turns(operation, turns)
+    local state = _99.__get_state()
+    local source
+
+    if operation == "vibe" then
+      source = Prompt.vibe(state)
+    elseif operation == "search" then
+      source = Prompt.search(state)
+    elseif operation == "tutorial" then
+      source = Prompt.tutorial(state)
+    elseif operation == "visual" then
+      -- For visual, we need a buffer with content and selection
+      local buffer = test_utils.create_file({ "local value = 1" }, "lua", 1, 0)
+      vim.api.nvim_win_set_cursor(0, { 1, 0 })
+      vim.cmd("normal! v$")
+      source = Prompt.visual(state)
+      -- Exit visual mode after creating the prompt
+      vim.api.nvim_feedkeys(
+        vim.api.nvim_replace_termcodes("<Esc>", true, false, true),
+        "n",
+        false
+      )
+    else
+      error("unknown operation: " .. tostring(operation))
+    end
+
+    source.state = "success"
+    source.user_prompt = turns[1] and turns[1].user_prompt or "test prompt"
+
+    -- Add turns
+    for _, turn in ipairs(turns) do
+      source:append_turn(turn.user_prompt, turn.response)
+    end
+
+    return source
+  end
+
+  it(
+    "continues latest vibe source by dispatching vibe op with stitched prompt",
+    function()
+      local provider = test_utils.TestProvider.new()
+      _99.setup(test_utils.get_test_setup_options({
+        in_flight_options = { enable = false },
+      }, provider))
+
+      -- Create a source vibe prompt with turns
+      local source = create_source_with_turns("vibe", {
+        { user_prompt = "make this clearer", response = "first vibe response" },
+      })
+
+      local ops = require("99.ops")
+      local state = _99.__get_state()
+
+      -- Call continue.run directly
+      local xid = continue_module.run(state, ops, source, {
+        additional_prompt = "less abstraction",
+      })
+
+      -- Verify a request was made
+      assert(xid, "expected xid to be returned")
+      assert(provider.request, "expected provider.request to be set")
+
+      -- Verify the operation is vibe
+      eq("vibe", provider.request.prompt.operation)
+
+      -- Verify the stitched prompt contains the conversation history
+      local query = provider.request.query
+      assert.matches("continuing a previous 99.vibe request", query, 1, true)
+      assert.matches("make this clearer", query, 1, true)
+      assert.matches("first vibe response", query, 1, true)
+      assert.matches("less abstraction", query, 1, true)
+    end
+  )
+
+  it("continues latest search source with search op", function()
+    local provider = test_utils.TestProvider.new()
+    _99.setup(test_utils.get_test_setup_options({
+      in_flight_options = { enable = false },
+    }, provider))
+
+    -- Create a source search prompt with turns
+    local source = create_source_with_turns("search", {
+      {
+        user_prompt = "find parser",
+        response = "src/parser.lua:1: parser found",
+      },
+    })
+
+    local ops = require("99.ops")
+    local state = _99.__get_state()
+
+    -- Call continue.run directly
+    local xid = continue_module.run(state, ops, source, {
+      additional_prompt = "narrow to tests",
+    })
+
+    -- Verify a request was made
+    assert(xid, "expected xid to be returned")
+    assert(provider.request, "expected provider.request to be set")
+
+    -- Verify the operation is search
+    eq("search", provider.request.prompt.operation)
+
+    -- Verify the stitched prompt contains the conversation history
+    local query = provider.request.query
+    assert.matches("continuing a previous 99.search request", query, 1, true)
+    assert.matches("find parser", query, 1, true)
+    assert.matches("src/parser.lua:1: parser found", query, 1, true)
+    assert.matches("narrow to tests", query, 1, true)
+  end)
+
+  it(
+    "returns nil and does not start provider when source has no turns",
+    function()
+      local provider = test_utils.TestProvider.new()
+      _99.setup(test_utils.get_test_setup_options({
+        in_flight_options = { enable = false },
+      }, provider))
+
+      -- Create a source vibe prompt WITHOUT turns
+      local source = Prompt.vibe(_99.__get_state())
+      source.state = "success"
+      source.user_prompt = "test prompt"
+      -- Intentionally NOT adding any turns
+
+      local ops = require("99.ops")
+      local state = _99.__get_state()
+
+      -- Call continue.run directly
+      local xid = continue_module.run(state, ops, source, {
+        additional_prompt = "try again",
+      })
+
+      -- Verify no request was made
+      eq(nil, xid)
+      eq(nil, provider.request)
+    end
+  )
+
+  it("returns nil when additional_prompt is not provided", function()
+    local provider = test_utils.TestProvider.new()
+    _99.setup(test_utils.get_test_setup_options({
+      in_flight_options = { enable = false },
+    }, provider))
+
+    -- Create a source with turns
+    local source = create_source_with_turns("vibe", {
+      { user_prompt = "test", response = "response" },
+    })
+
+    local ops = require("99.ops")
+    local state = _99.__get_state()
+
+    -- Call continue.run without additional_prompt
+    local xid = continue_module.run(state, ops, source, {})
+
+    -- Verify no request was made
+    eq(nil, xid)
+    eq(nil, provider.request)
+  end)
+
+  it("returns nil when additional_prompt is empty string", function()
+    local provider = test_utils.TestProvider.new()
+    _99.setup(test_utils.get_test_setup_options({
+      in_flight_options = { enable = false },
+    }, provider))
+
+    -- Create a source with turns
+    local source = create_source_with_turns("vibe", {
+      { user_prompt = "test", response = "response" },
+    })
+
+    local ops = require("99.ops")
+    local state = _99.__get_state()
+
+    -- Call continue.run with empty additional_prompt
+    local xid = continue_module.run(state, ops, source, {
+      additional_prompt = "",
+    })
+
+    -- Verify no request was made
+    eq(nil, xid)
+    eq(nil, provider.request)
+  end)
+
+  it("preserves session_id and turns in continued context", function()
+    local provider = test_utils.TestProvider.new()
+    _99.setup(test_utils.get_test_setup_options({
+      in_flight_options = { enable = false },
+    }, provider))
+
+    -- Create a source with multiple turns
+    local source = create_source_with_turns("vibe", {
+      { user_prompt = "first prompt", response = "first response" },
+      { user_prompt = "second prompt", response = "second response" },
+    })
+
+    local original_session_id = source.session_id
+    local original_turns_count = #source.turns
+
+    local ops = require("99.ops")
+    local state = _99.__get_state()
+
+    -- Call continue.run
+    continue_module.run(state, ops, source, {
+      additional_prompt = "third prompt",
+    })
+
+    -- Verify the new context has the same session_id
+    eq(original_session_id, provider.request.prompt.session_id)
+
+    -- Verify the new context has the turns copied
+    eq(original_turns_count, #provider.request.prompt.turns)
+    eq("first prompt", provider.request.prompt.turns[1].user_prompt)
+    eq("second prompt", provider.request.prompt.turns[2].user_prompt)
+  end)
+
+  it("returns nil when source is nil", function()
+    local provider = test_utils.TestProvider.new()
+    _99.setup(test_utils.get_test_setup_options({
+      in_flight_options = { enable = false },
+    }, provider))
+
+    local ops = require("99.ops")
+    local state = _99.__get_state()
+
+    -- Call continue.run with nil source
+    local xid = continue_module.run(state, ops, nil, {
+      additional_prompt = "test prompt",
+    })
+
+    -- Verify no request was made
+    eq(nil, xid)
+    eq(nil, provider.request)
+  end)
+
+  it("returns nil for unsupported source.operation", function()
+    local provider = test_utils.TestProvider.new()
+    _99.setup(test_utils.get_test_setup_options({
+      in_flight_options = { enable = false },
+    }, provider))
+
+    -- Create a source with an unsupported operation
+    local source = Prompt.vibe(_99.__get_state())
+    source.state = "success"
+    source.operation = "unsupported_op"
+    source:append_turn("test prompt", "test response")
+
+    local ops = require("99.ops")
+    local state = _99.__get_state()
+
+    -- Call continue.run with unsupported operation
+    local xid = continue_module.run(state, ops, source, {
+      additional_prompt = "test follow up",
+    })
+
+    -- Verify no request was made
+    eq(nil, xid)
+    eq(nil, provider.request)
+  end)
+
+  it("uses only last 3 turns in continuation prompt", function()
+    local provider = test_utils.TestProvider.new()
+    _99.setup(test_utils.get_test_setup_options({
+      in_flight_options = { enable = false },
+    }, provider))
+
+    -- Create a source with 5 turns
+    local source = create_source_with_turns("vibe", {
+      { user_prompt = "first prompt", response = "first response" },
+      { user_prompt = "second prompt", response = "second response" },
+      { user_prompt = "third prompt", response = "third response" },
+      { user_prompt = "fourth prompt", response = "fourth response" },
+      { user_prompt = "fifth prompt", response = "fifth response" },
+    })
+
+    local ops = require("99.ops")
+    local state = _99.__get_state()
+
+    -- Call continue.run
+    continue_module.run(state, ops, source, {
+      additional_prompt = "sixth prompt",
+    })
+
+    -- Verify the query contains only the last 3 turns
+    local query = provider.request.query
+
+    -- Should NOT contain the first two turns
+    assert.not_matches("first prompt", query, 1, true)
+    assert.not_matches("first response", query, 1, true)
+    assert.not_matches("second prompt", query, 1, true)
+    assert.not_matches("second response", query, 1, true)
+
+    -- Should contain the last 3 turns (3rd, 4th, 5th)
+    assert.matches("third prompt", query, 1, true)
+    assert.matches("third response", query, 1, true)
+    assert.matches("fourth prompt", query, 1, true)
+    assert.matches("fourth response", query, 1, true)
+    assert.matches("fifth prompt", query, 1, true)
+    assert.matches("fifth response", query, 1, true)
+
+    -- Should contain the follow-up
+    assert.matches("sixth prompt", query, 1, true)
+  end)
+end)
+
+describe("_99.continue public API", function()
+  after_each(function()
+    test_utils.clean_files()
+    -- Ensure we exit visual mode after each test
+    vim.api.nvim_feedkeys(
+      vim.api.nvim_replace_termcodes("<Esc>", true, false, true),
+      "n",
+      false
+    )
+  end)
+
+  it(
+    "continues latest successful vibe with last=true and additional_prompt",
+    function()
+      local provider = test_utils.TestProvider.new()
+      _99.setup(test_utils.get_test_setup_options({
+        in_flight_options = { enable = false },
+      }, provider))
+      test_utils.create_file({ "local value = 1" }, "lua", 1, 0)
+
+      -- First, make a successful vibe request
+      _99.vibe({ additional_prompt = "make this clearer" })
+      provider:resolve("success", "first vibe response")
+      test_utils.next_frame()
+
+      -- Now continue it using the public API
+      local xid =
+        _99.continue({ last = true, additional_prompt = "less abstraction" })
+
+      -- Verify a request was made
+      assert(xid, "expected xid to be returned")
+      assert(provider.request, "expected provider.request to be set")
+
+      -- Verify the operation is vibe
+      eq("vibe", provider.request.prompt.operation)
+
+      -- Verify the stitched prompt contains the conversation history
+      local query = provider.request.query
+      assert.matches("make this clearer", query, 1, true)
+      assert.matches("first vibe response", query, 1, true)
+      assert.matches("less abstraction", query, 1, true)
+    end
+  )
+
+  it(
+    "captures last=true follow-up without mutating the source prompt",
+    function()
+      local provider = test_utils.TestProvider.new()
+      _99.setup(test_utils.get_test_setup_options({
+        in_flight_options = { enable = false },
+      }, provider))
+      test_utils.create_file({ "local value = 1" }, "lua", 1, 0)
+
+      _99.vibe({ additional_prompt = "make this clearer" })
+      provider:resolve("success", "first vibe response")
+      test_utils.next_frame()
+
+      local source = _99.__get_state().tracking:latest_successful("vibe")
+      assert(source, "expected a successful source request")
+      eq("make this clearer", source.user_prompt)
+
+      local previous_capture_input = Window.capture_input
+      Window.capture_input = function(_, opts)
+        opts.cb(true, "less abstraction")
+      end
+
+      local ok, err = pcall(function()
+        local xid = _99.continue({ last = true })
+
+        eq(nil, xid)
+        eq("make this clearer", source.user_prompt)
+        assert(provider.request, "expected provider.request to be set")
+        eq("vibe", provider.request.prompt.operation)
+        assert.matches("less abstraction", provider.request.query, 1, true)
+      end)
+
+      Window.capture_input = previous_capture_input
+      if not ok then
+        error(err)
+      end
+    end
+  )
+
+  it(
+    "captures selected follow-up without mutating the source prompt",
+    function()
+      local provider = test_utils.TestProvider.new()
+      _99.setup(test_utils.get_test_setup_options({
+        in_flight_options = { enable = false },
+      }, provider))
+      test_utils.create_file({ "local value = 1" }, "lua", 1, 0)
+
+      _99.vibe({ additional_prompt = "make this clearer" })
+      provider:resolve("success", "first vibe response")
+      test_utils.next_frame()
+
+      local source = _99.__get_state().tracking:latest_successful("vibe")
+      assert(source, "expected a successful source request")
+      eq("make this clearer", source.user_prompt)
+
+      local previous_capture_input = Window.capture_input
+      local previous_capture_select_input = Window.capture_select_input
+      Window.capture_select_input = function(_, opts)
+        opts.cb(true, opts.content[1])
+      end
+      Window.capture_input = function(_, opts)
+        opts.cb(true, "less abstraction")
+      end
+
+      local ok, err = pcall(function()
+        local xid = _99.continue()
+
+        eq(nil, xid)
+        eq("make this clearer", source.user_prompt)
+        assert(provider.request, "expected provider.request to be set")
+        eq("vibe", provider.request.prompt.operation)
+        assert.matches("less abstraction", provider.request.query, 1, true)
+      end)
+
+      Window.capture_input = previous_capture_input
+      Window.capture_select_input = previous_capture_select_input
+      if not ok then
+        error(err)
+      end
+    end
+  )
+
+  it("continues latest search by type even when newer vibe exists", function()
+    local provider = test_utils.TestProvider.new()
+    _99.setup(test_utils.get_test_setup_options({
+      in_flight_options = { enable = false },
+    }, provider))
+    test_utils.create_file({ "local value = 1" }, "lua", 1, 0)
+
+    -- First, make a successful search request
+    _99.search({ additional_prompt = "find parser" })
+    provider:resolve("success", "src/parser.lua:1: parser found")
+    test_utils.next_frame()
+
+    -- Then make a newer vibe request
+    _99.vibe({ additional_prompt = "explain parser" })
+    provider:resolve("success", "vibe response")
+    test_utils.next_frame()
+
+    -- Now continue the search (not the vibe) using type filter
+    local xid = _99.continue({
+      type = "search",
+      last = true,
+      additional_prompt = "narrow to tests",
+    })
+
+    -- Verify a request was made
+    assert(xid, "expected xid to be returned")
+    assert(provider.request, "expected provider.request to be set")
+
+    -- Verify the operation is search (not vibe)
+    eq("search", provider.request.prompt.operation)
+
+    -- Verify the stitched prompt contains the search conversation history
+    local query = provider.request.query
+    assert.matches("find parser", query, 1, true)
+    assert.matches("src/parser.lua:1: parser found", query, 1, true)
+    assert.matches("narrow to tests", query, 1, true)
+  end)
+
+  it(
+    "returns nil and does not call provider when no previous success exists",
+    function()
+      local provider = test_utils.TestProvider.new()
+      _99.setup(test_utils.get_test_setup_options({
+        in_flight_options = { enable = false },
+      }, provider))
+      test_utils.create_file({ "local value = 1" }, "lua", 1, 0)
+
+      -- Try to continue without any successful requests
+      local xid = _99.continue({ last = true, additional_prompt = "try again" })
+
+      -- Verify no request was made
+      eq(nil, xid)
+      eq(nil, provider.request)
+    end
+  )
+
+  it(
+    "refuses visual continuation without a current visual selection",
+    function()
+      local provider = test_utils.TestProvider.new()
+      _99.setup(test_utils.get_test_setup_options({
+        in_flight_options = { enable = false },
+      }, provider))
+
+      -- Create a buffer with content and set up visual source
+      local buffer = test_utils.create_file({ "local value = 1" }, "lua", 1, 0)
+      vim.api.nvim_win_set_cursor(0, { 1, 0 })
+      vim.cmd("normal! v$")
+
+      local source = Prompt.visual(_99.__get_state())
+      source.state = "success"
+      source.user_prompt = "rewrite selection"
+      source:append_turn("rewrite selection", "local value = 2")
+
+      -- Exit visual mode - this is key for the test
+      vim.api.nvim_feedkeys(
+        vim.api.nvim_replace_termcodes("<Esc>", true, false, true),
+        "n",
+        false
+      )
+      test_utils.next_frame()
+
+      local ops = require("99.ops")
+      local state = _99.__get_state()
+
+      -- Call continue.run - should refuse because we're not in visual mode
+      local xid = continue_module.run(state, ops, source, {
+        additional_prompt = "make it clearer",
+      })
+
+      -- Verify no request was made
+      eq(nil, xid)
+      eq(nil, provider.request)
+    end
+  )
+
+  it("continues visual requests against the current selection", function()
+    local provider = test_utils.TestProvider.new()
+    _99.setup(test_utils.get_test_setup_options({
+      in_flight_options = { enable = false },
+    }, provider))
+
+    -- Create a buffer with content
+    local buffer = test_utils.create_file({
+      "local value = 1",
+      "return value",
+    }, "lua", 1, 0)
+
+    -- First visual request: select first line
+    vim.api.nvim_win_set_cursor(0, { 1, 0 })
+    vim.cmd("normal! v$")
+
+    local source = Prompt.visual(_99.__get_state())
+    source.state = "success"
+    source.user_prompt = "rewrite selection"
+    source:append_turn("rewrite selection", "local value = 2")
+
+    -- Exit visual mode
+    vim.api.nvim_feedkeys(
+      vim.api.nvim_replace_termcodes("<Esc>", true, false, true),
+      "n",
+      false
+    )
+    test_utils.next_frame()
+
+    local ops = require("99.ops")
+    local state = _99.__get_state()
+
+    -- Now set up a NEW visual selection for the continuation (second line)
+    vim.api.nvim_win_set_cursor(0, { 2, 0 })
+    vim.cmd("normal! v$")
+    test_utils.next_frame()
+
+    -- Call continue.run - should succeed because we have a fresh visual selection
+    local xid = continue_module.run(state, ops, source, {
+      additional_prompt = "rewrite return too",
+    })
+
+    -- Verify a request was made
+    assert(xid, "expected xid to be returned")
+    assert(provider.request, "expected provider.request to be set")
+
+    -- Verify the operation is visual
+    eq("visual", provider.request.prompt.operation)
+
+    -- Verify the stitched prompt contains the conversation history
+    local query = provider.request.query
+    assert.matches("rewrite selection", query, 1, true)
+    assert.matches("local value = 2", query, 1, true)
+    assert.matches("rewrite return too", query, 1, true)
+  end)
+end)

--- a/lua/99/test/prompt_spec.lua
+++ b/lua/99/test/prompt_spec.lua
@@ -24,4 +24,335 @@ describe("prompt", function()
     eq("find important changes", prompt.user_prompt)
     eq("search: find important changes", prompt:summary())
   end)
+
+  it("normalizes old serialized prompts into one-turn sessions", function()
+    local provider = test_utils.TestProvider.new()
+    _99.setup(test_utils.get_test_setup_options({}, provider))
+
+    local state = _99.__get_state()
+
+    -- Test search type with response
+    local search_prompt = Prompt.deserialize(state, {
+      user_prompt = "search query",
+      data = {
+        type = "search",
+        qfix_items = {},
+        response = "search response",
+      },
+    })
+
+    eq(1, #search_prompt.turns)
+    eq("search query", search_prompt.turns[1].user_prompt)
+    eq("search response", search_prompt.turns[1].response)
+    assert.is_string(search_prompt.session_id)
+
+    -- Test tutorial type with tutorial lines
+    local tutorial_prompt = Prompt.deserialize(state, {
+      user_prompt = "tutorial query",
+      data = {
+        type = "tutorial",
+        buffer = 0,
+        window = 0,
+        xid = 1,
+        tutorial = { "line 1", "line 2", "line 3" },
+      },
+    })
+
+    eq(1, #tutorial_prompt.turns)
+    eq("tutorial query", tutorial_prompt.turns[1].user_prompt)
+    eq("line 1\nline 2\nline 3", tutorial_prompt.turns[1].response)
+
+    -- Test vibe type with response
+    local vibe_prompt = Prompt.deserialize(state, {
+      user_prompt = "vibe query",
+      data = {
+        type = "vibe",
+        qfix_items = {},
+        response = "vibe response",
+      },
+    })
+
+    eq(1, #vibe_prompt.turns)
+    eq("vibe query", vibe_prompt.turns[1].user_prompt)
+    eq("vibe response", vibe_prompt.turns[1].response)
+
+    -- Test that new format with turns is preserved
+    local new_format_prompt = Prompt.deserialize(state, {
+      user_prompt = "new query",
+      session_id = "session-123",
+      data = {
+        type = "search",
+        qfix_items = {},
+        response = "new response",
+      },
+      turns = {
+        { user_prompt = "turn 1", response = "response 1" },
+        { user_prompt = "turn 2", response = "response 2" },
+      },
+    })
+
+    eq("session-123", new_format_prompt.session_id)
+    eq(2, #new_format_prompt.turns)
+    eq("turn 1", new_format_prompt.turns[1].user_prompt)
+    eq("turn 2", new_format_prompt.turns[2].user_prompt)
+  end)
+
+  it("serializes session id and turns", function()
+    local provider = test_utils.TestProvider.new()
+    _99.setup(test_utils.get_test_setup_options({}, provider))
+
+    local state = _99.__get_state()
+    local prompt = Prompt.search(state)
+    prompt.user_prompt = "test query"
+    prompt.state = "success"
+    prompt.session_id = "test-session-456"
+    prompt.turns = {
+      { user_prompt = "query 1", response = "response 1" },
+      { user_prompt = "query 2", response = "response 2" },
+    }
+
+    local serialized = prompt:serialize()
+
+    eq("test-session-456", serialized.session_id)
+    eq(2, #serialized.turns)
+    eq("query 1", serialized.turns[1].user_prompt)
+    eq("response 1", serialized.turns[1].response)
+    eq("query 2", serialized.turns[2].user_prompt)
+    eq("response 2", serialized.turns[2].response)
+  end)
+
+  it("returns recent turns without mutating stored turns", function()
+    local provider = test_utils.TestProvider.new()
+    _99.setup(test_utils.get_test_setup_options({}, provider))
+
+    local state = _99.__get_state()
+    local prompt = Prompt.search(state)
+    prompt.turns = {
+      { user_prompt = "query 1", response = "response 1" },
+      { user_prompt = "query 2", response = "response 2" },
+      { user_prompt = "query 3", response = "response 3" },
+      { user_prompt = "query 4", response = "response 4" },
+      { user_prompt = "query 5", response = "response 5" },
+    }
+
+    -- Get last 3 turns
+    local recent = prompt:recent_turns(3)
+
+    eq(3, #recent)
+    eq("query 3", recent[1].user_prompt)
+    eq("query 4", recent[2].user_prompt)
+    eq("query 5", recent[3].user_prompt)
+
+    -- Verify original turns are unchanged
+    eq(5, #prompt.turns)
+    eq("query 1", prompt.turns[1].user_prompt)
+    eq("query 5", prompt.turns[5].user_prompt)
+
+    -- Verify modifying recent doesn't affect stored turns
+    recent[1].user_prompt = "modified"
+    eq("query 3", prompt.turns[3].user_prompt)
+
+    -- Test with max larger than turns count
+    local all_recent = prompt:recent_turns(10)
+    eq(5, #all_recent)
+
+    -- Test with max of 1
+    local last_recent = prompt:recent_turns(1)
+    eq(1, #last_recent)
+    eq("query 5", last_recent[1].user_prompt)
+
+    -- Test with max <= 0 returns empty table
+    eq({}, prompt:recent_turns(0))
+    eq({}, prompt:recent_turns(-1))
+  end)
+
+  it("round-trip serialization preserves data and runtime fields", function()
+    local provider = test_utils.TestProvider.new()
+    _99.setup(test_utils.get_test_setup_options({}, provider))
+
+    local state = _99.__get_state()
+
+    -- Create a prompt with turns
+    local original = Prompt.search(state)
+    original.user_prompt = "round-trip test"
+    original.state = "success"
+    original.session_id = "round-trip-session-123"
+    original.turns = {
+      { user_prompt = "turn 1", response = "response 1" },
+      { user_prompt = "turn 2", response = "response 2" },
+    }
+
+    -- Serialize
+    local serialized = original:serialize()
+
+    -- Verify serialized data
+    eq("round-trip test", serialized.user_prompt)
+    eq("round-trip-session-123", serialized.session_id)
+    eq(2, #serialized.turns)
+    eq("search", serialized.data.type)
+
+    -- Deserialize
+    local deserialized = Prompt.deserialize(state, serialized)
+
+    -- Verify deserialized data matches original
+    eq("round-trip test", deserialized.user_prompt)
+    eq("round-trip-session-123", deserialized.session_id)
+    eq(2, #deserialized.turns)
+    eq("turn 1", deserialized.turns[1].user_prompt)
+    eq("response 1", deserialized.turns[1].response)
+    eq("turn 2", deserialized.turns[2].user_prompt)
+    eq("response 2", deserialized.turns[2].response)
+    eq("search", deserialized.operation)
+    eq("search", deserialized.data.type)
+    eq("success", deserialized.state)
+
+    -- Verify runtime fields from set_defaults exist and are valid
+    assert.is_number(deserialized.xid)
+    assert.is_table(deserialized.logger)
+    assert.is_string(deserialized.tmp_file)
+    assert.is_table(deserialized.agent_context)
+    assert.is_table(deserialized.clean_ups)
+    assert.is_table(deserialized.marks)
+    assert.is_table(deserialized.md_file_names)
+    assert.is_string(deserialized.full_path)
+    assert.is_number(deserialized.started_at)
+  end)
+
+  it("builds a continuation prompt from recent turns and follow-up", function()
+    local provider = test_utils.TestProvider.new()
+    _99.setup(test_utils.get_test_setup_options({}, provider))
+
+    local prompts = _99.__get_state().prompts.prompts
+    local prompt = prompts.continue_chat("vibe", {
+      { user_prompt = "make this clearer", response = "first answer" },
+      { user_prompt = "less abstraction", response = "second answer" },
+    }, "keep the original style")
+
+    assert.matches("continuing a previous 99.vibe request", prompt, 1, true)
+    assert.matches("make this clearer", prompt, 1, true)
+    assert.matches("first answer", prompt, 1, true)
+    assert.matches("less abstraction", prompt, 1, true)
+    assert.matches("second answer", prompt, 1, true)
+    assert.matches("keep the original style", prompt, 1, true)
+    assert.matches(
+      "Preserve the output format expected by 99.vibe",
+      prompt,
+      1,
+      true
+    )
+  end)
+
+  it("continue_chat includes TEMP_FILE instruction", function()
+    local provider = test_utils.TestProvider.new()
+    _99.setup(test_utils.get_test_setup_options({}, provider))
+
+    local prompts = _99.__get_state().prompts.prompts
+    local prompt = prompts.continue_chat("tutorial", {
+      { user_prompt = "explain this", response = "first explanation" },
+    }, "go deeper")
+
+    -- Verify the prompt includes TEMP_FILE instruction
+    assert.matches("TEMP_FILE", prompt, 1, true)
+    assert.matches("not provided conversationally", prompt, 1, true)
+  end)
+
+  it("serialize includes started_at and completed_at timestamps", function()
+    local provider = test_utils.TestProvider.new()
+    _99.setup(test_utils.get_test_setup_options({}, provider))
+
+    local state = _99.__get_state()
+    local prompt = Prompt.search(state)
+    prompt.user_prompt = "timestamp test"
+    prompt.state = "success"
+    prompt.started_at = 1000
+    prompt.completed_at = 2000
+
+    local serialized = prompt:serialize()
+
+    eq(1000, serialized.started_at)
+    eq(2000, serialized.completed_at)
+  end)
+
+  it(
+    "deserialize preserves started_at and completed_at from serialized data",
+    function()
+      local provider = test_utils.TestProvider.new()
+      _99.setup(test_utils.get_test_setup_options({}, provider))
+
+      local state = _99.__get_state()
+      local prompt = Prompt.deserialize(state, {
+        user_prompt = "timestamp test",
+        data = {
+          type = "search",
+          qfix_items = {},
+          response = "",
+        },
+        started_at = 5000,
+        completed_at = 6000,
+      })
+
+      eq(5000, prompt.started_at)
+      eq(6000, prompt.completed_at)
+    end
+  )
+
+  it(
+    "deserialize keeps old serialized prompts valid without completed_at",
+    function()
+      local provider = test_utils.TestProvider.new()
+      _99.setup(test_utils.get_test_setup_options({}, provider))
+
+      local state = _99.__get_state()
+      local prompt = Prompt.deserialize(state, {
+        user_prompt = "old format test",
+        data = {
+          type = "search",
+          qfix_items = {},
+          response = "",
+        },
+        -- No started_at or completed_at
+      })
+
+      -- Old serialized prompts did not store timestamps. They still get a runtime
+      -- started_at from set_defaults, while completed_at remains absent so
+      -- tracking can fall back to started_at without inventing completion order.
+      assert.is_number(prompt.started_at)
+      eq(nil, prompt.completed_at)
+    end
+  )
+
+  it(
+    "timestamp round-trip preserves values through serialize/deserialize",
+    function()
+      local provider = test_utils.TestProvider.new()
+      _99.setup(test_utils.get_test_setup_options({}, provider))
+
+      local state = _99.__get_state()
+
+      -- Create a prompt with specific timestamps
+      local original = Prompt.search(state)
+      original.user_prompt = "round-trip timestamps"
+      original.state = "success"
+      original.started_at = 12345
+      original.completed_at = 67890
+      original.session_id = "test-session"
+      original.turns = {
+        { user_prompt = "query", response = "response" },
+      }
+
+      -- Serialize
+      local serialized = original:serialize()
+
+      -- Verify serialized timestamps
+      eq(12345, serialized.started_at)
+      eq(67890, serialized.completed_at)
+
+      -- Deserialize
+      local deserialized = Prompt.deserialize(state, serialized)
+
+      -- Verify deserialized timestamps match original
+      eq(12345, deserialized.started_at)
+      eq(67890, deserialized.completed_at)
+    end
+  )
 end)

--- a/lua/99/test/providers_spec.lua
+++ b/lua/99/test/providers_spec.lua
@@ -178,4 +178,228 @@ describe("providers", function()
       eq("function", type(Providers.GeminiCLIProvider.make_request))
     end)
   end)
+
+  describe("stdout fallback for tutorial operation", function()
+    local test_utils = require("99.test.test_utils")
+    local Prompt = require("99.prompt")
+
+    it("uses stdout when temp file is empty for tutorial context", function()
+      local _99 = require("99")
+      local provider = test_utils.TestProvider.new()
+      _99.setup(test_utils.get_test_setup_options({}, provider))
+
+      local state = _99.__get_state()
+      local context = Prompt.tutorial(state)
+      context.user_prompt = "test tutorial"
+      context:finalize()
+
+      -- Create the temp file but leave it empty
+      local tmp_file = context.tmp_file
+      local file = io.open(tmp_file, "w")
+      if file then
+        file:write("")
+        file:close()
+      end
+
+      local complete_status = nil
+      local complete_result = nil
+
+      local observer = {
+        on_start = function() end,
+        on_complete = function(status, res)
+          complete_status = status
+          complete_result = res
+        end,
+        on_stderr = function() end,
+        on_stdout = function() end,
+      }
+
+      -- Stub vim.system to simulate OpenCode writing to stdout instead of temp file
+      local original_vim_system = vim.system
+      local stdout_chunks =
+        { "# Tutorial Title\n", "\n", "This is tutorial content from stdout." }
+      local captured_stdout = {}
+
+      vim.system = function(_cmd, opts, callback)
+        -- Simulate stdout callback with tutorial content
+        for _, chunk in ipairs(stdout_chunks) do
+          if opts.stdout then
+            opts.stdout(nil, chunk)
+            table.insert(captured_stdout, chunk)
+          end
+        end
+
+        -- Simulate process exit with code 0
+        vim.schedule(function()
+          callback({
+            code = 0,
+            stdout = table.concat(stdout_chunks),
+            stderr = "",
+          })
+        end)
+
+        -- Return a mock process object
+        return { pid = 12345 }
+      end
+
+      -- Make the request
+      Providers.OpenCodeProvider:make_request("test query", context, observer)
+
+      -- Wait for the async callback
+      test_utils.next_frame()
+
+      -- Restore original vim.system
+      vim.system = original_vim_system
+
+      -- Verify that on_complete was called with success and the stdout content
+      eq("success", complete_status)
+      eq(
+        "# Tutorial Title\n\nThis is tutorial content from stdout.",
+        complete_result
+      )
+    end)
+
+    it("does NOT use stdout fallback for search operation", function()
+      local _99 = require("99")
+      local provider = test_utils.TestProvider.new()
+      _99.setup(test_utils.get_test_setup_options({}, provider))
+
+      local state = _99.__get_state()
+      local context = Prompt.search(state)
+      context.user_prompt = "test search"
+      context:finalize()
+
+      -- Create the temp file but leave it empty
+      local tmp_file = context.tmp_file
+      local file = io.open(tmp_file, "w")
+      if file then
+        file:write("")
+        file:close()
+      end
+
+      local complete_status = nil
+      local complete_result = nil
+
+      local observer = {
+        on_start = function() end,
+        on_complete = function(status, res)
+          complete_status = status
+          complete_result = res
+        end,
+        on_stderr = function() end,
+        on_stdout = function() end,
+      }
+
+      -- Stub vim.system to simulate OpenCode writing to stdout instead of temp file
+      local original_vim_system = vim.system
+      local stdout_chunks = { "/path/to/file.lua:1:1,5,some search result\n" }
+
+      vim.system = function(_cmd, opts, callback)
+        -- Simulate stdout callback with search content
+        for _, chunk in ipairs(stdout_chunks) do
+          if opts.stdout then
+            opts.stdout(nil, chunk)
+          end
+        end
+
+        -- Simulate process exit with code 0
+        vim.schedule(function()
+          callback({
+            code = 0,
+            stdout = table.concat(stdout_chunks),
+            stderr = "",
+          })
+        end)
+
+        -- Return a mock process object
+        return { pid = 12345 }
+      end
+
+      -- Make the request
+      Providers.OpenCodeProvider:make_request("test query", context, observer)
+
+      -- Wait for the async callback
+      test_utils.next_frame()
+
+      -- Restore original vim.system
+      vim.system = original_vim_system
+
+      -- Verify that on_complete was called with success but EMPTY result (not stdout)
+      eq("success", complete_status)
+      eq("", complete_result)
+    end)
+
+    it("uses temp file content when it is non-empty for tutorial", function()
+      local _99 = require("99")
+      local provider = test_utils.TestProvider.new()
+      _99.setup(test_utils.get_test_setup_options({}, provider))
+
+      local state = _99.__get_state()
+      local context = Prompt.tutorial(state)
+      context.user_prompt = "test tutorial"
+      context:finalize()
+
+      -- Create the temp file with actual content
+      local tmp_file = context.tmp_file
+      local file = io.open(tmp_file, "w")
+      if file then
+        file:write("# Tutorial from temp file\n\nThis is the real content.")
+        file:close()
+      end
+
+      local complete_status = nil
+      local complete_result = nil
+
+      local observer = {
+        on_start = function() end,
+        on_complete = function(status, res)
+          complete_status = status
+          complete_result = res
+        end,
+        on_stderr = function() end,
+        on_stdout = function() end,
+      }
+
+      -- Stub vim.system
+      local original_vim_system = vim.system
+      local stdout_chunks =
+        { "# Tutorial from stdout\n\nThis should be ignored." }
+
+      vim.system = function(_cmd, opts, callback)
+        -- Simulate stdout callback
+        for _, chunk in ipairs(stdout_chunks) do
+          if opts.stdout then
+            opts.stdout(nil, chunk)
+          end
+        end
+
+        -- Simulate process exit with code 0
+        vim.schedule(function()
+          callback({
+            code = 0,
+            stdout = table.concat(stdout_chunks),
+            stderr = "",
+          })
+        end)
+
+        return { pid = 12345 }
+      end
+
+      -- Make the request
+      Providers.OpenCodeProvider:make_request("test query", context, observer)
+
+      -- Wait for the async callback
+      test_utils.next_frame()
+
+      -- Restore original vim.system
+      vim.system = original_vim_system
+
+      -- Verify that on_complete was called with temp file content, not stdout
+      eq("success", complete_status)
+      eq(
+        "# Tutorial from temp file\n\nThis is the real content.",
+        complete_result
+      )
+    end)
+  end)
 end)

--- a/lua/99/test/tracking_spec.lua
+++ b/lua/99/test/tracking_spec.lua
@@ -1,6 +1,7 @@
 -- luacheck: globals describe it assert
 local _99 = require("99")
 local Tracking = require("99.state.tracking")
+local Prompt = require("99.prompt")
 local test_utils = require("99.test.test_utils")
 local eq = assert.are.same
 
@@ -76,4 +77,280 @@ describe("tracking", function()
     eq("second success", successful[2].user_prompt)
     eq("first success", successful[3].user_prompt)
   end)
+
+  it("finds latest successful request across all modes", function()
+    local provider = test_utils.TestProvider.new()
+    _99.setup(test_utils.get_test_setup_options({
+      in_flight_options = { enable = false },
+    }, provider))
+    test_utils.create_file({ "local value = 1" }, "lua", 1, 0)
+
+    run(provider, "search", "success", "first search")
+    run(provider, "vibe", "failed", "failed vibe")
+    run(provider, "tutorial", "success", "latest tutorial")
+
+    local latest = _99.__get_state().tracking:latest_successful()
+
+    assert(latest)
+    eq("tutorial", latest.operation)
+    eq("latest tutorial", latest.user_prompt)
+  end)
+
+  it("finds latest successful request by mode", function()
+    local provider = test_utils.TestProvider.new()
+    _99.setup(test_utils.get_test_setup_options({
+      in_flight_options = { enable = false },
+    }, provider))
+    test_utils.create_file({ "local value = 1" }, "lua", 1, 0)
+
+    run(provider, "search", "success", "old search")
+    run(provider, "vibe", "success", "new vibe")
+
+    local latest_search = _99.__get_state().tracking:latest_successful("search")
+
+    assert(latest_search)
+    eq("search", latest_search.operation)
+    eq("old search", latest_search.user_prompt)
+  end)
+
+  it("returns nil when no matching successful request exists", function()
+    local provider = test_utils.TestProvider.new()
+    _99.setup(test_utils.get_test_setup_options({
+      in_flight_options = { enable = false },
+    }, provider))
+    test_utils.create_file({ "local value = 1" }, "lua", 1, 0)
+
+    run(provider, "search", "failed", "failed search")
+
+    eq(nil, _99.__get_state().tracking:latest_successful("search"))
+  end)
+
+  it("completed() does not count ready requests", function()
+    local provider = test_utils.TestProvider.new()
+    _99.setup(test_utils.get_test_setup_options({
+      in_flight_options = { enable = false },
+    }, provider))
+    test_utils.create_file({ "local value = 1" }, "lua", 1, 0)
+
+    local state = _99.__get_state()
+    local prompt = Prompt.search(state)
+    state.tracking:track(prompt)
+
+    eq(0, state.tracking:completed())
+    eq("ready", prompt.state)
+  end)
+
+  it(
+    "setup can set a count to 0 explicitly and serialization respects it",
+    function()
+      local previous_counts = vim.deepcopy(Tracking.__config.serialize_count)
+      Tracking.setup({
+        serialize_counts = {
+          vibe = 0,
+          search = 1,
+          tutorial = 1,
+          visual = 0,
+        },
+      })
+
+      local provider = test_utils.TestProvider.new()
+      _99.setup(test_utils.get_test_setup_options({
+        in_flight_options = { enable = false },
+      }, provider))
+      test_utils.create_file({ "local value = 1" }, "lua", 1, 0)
+
+      run(provider, "vibe", "success", "vibe request")
+      run(provider, "search", "success", "search request")
+
+      local serialized = _99.__get_state().tracking:serialize()
+      local vibe_count = 0
+      local search_count = 0
+
+      for _, request in ipairs(serialized.requests) do
+        if request.data.type == "vibe" then
+          vibe_count = vibe_count + 1
+        elseif request.data.type == "search" then
+          search_count = search_count + 1
+        end
+      end
+
+      eq(0, vibe_count)
+      eq(1, search_count)
+
+      Tracking.__config.serialize_count = previous_counts
+    end
+  )
+
+  it("serializes sessions by request count instead of turn count", function()
+    local previous_counts = vim.deepcopy(Tracking.__config.serialize_count)
+    Tracking.setup({
+      serialize_counts = {
+        vibe = 1,
+        search = 1,
+        tutorial = 3,
+        visual = 0,
+      },
+    })
+
+    local provider = test_utils.TestProvider.new()
+    _99.setup(test_utils.get_test_setup_options({
+      in_flight_options = { enable = false },
+    }, provider))
+    test_utils.create_file({ "local value = 1" }, "lua", 1, 0)
+
+    _99.vibe({ additional_prompt = "first vibe" })
+    provider:resolve("success", "first response")
+    test_utils.next_frame()
+    _99.continue({
+      type = "vibe",
+      last = true,
+      additional_prompt = "second vibe",
+    })
+    provider:resolve("success", "second response")
+    test_utils.next_frame()
+
+    local serialized = _99.__get_state().tracking:serialize()
+    local vibe_count = 0
+    local vibe_request = nil
+
+    for _, request in ipairs(serialized.requests) do
+      if request.data.type == "vibe" then
+        vibe_count = vibe_count + 1
+        vibe_request = request
+      end
+    end
+
+    eq(1, vibe_count)
+    assert(vibe_request)
+    eq(2, #vibe_request.turns)
+    eq("second vibe", vibe_request.turns[2].user_prompt)
+
+    Tracking.__config.serialize_count = previous_counts
+  end)
+
+  it(
+    "latest_successful returns most recently completed, not most recently started",
+    function()
+      local provider = test_utils.TestProvider.new()
+      _99.setup(test_utils.get_test_setup_options({
+        in_flight_options = { enable = false },
+      }, provider))
+
+      local state = _99.__get_state()
+
+      local prompt_a = Prompt.search(state)
+      prompt_a.user_prompt = "request A"
+      prompt_a.state = "success"
+      prompt_a.started_at = 100
+      prompt_a.completed_at = 300
+      prompt_a:append_turn("request A", "result A")
+      state.tracking:track(prompt_a)
+
+      local prompt_b = Prompt.search(state)
+      prompt_b.user_prompt = "request B"
+      prompt_b.state = "success"
+      prompt_b.started_at = 200
+      prompt_b.completed_at = 250
+      prompt_b:append_turn("request B", "result B")
+      state.tracking:track(prompt_b)
+
+      local latest = state.tracking:latest_successful()
+
+      -- Should return A because it completed later, even though B started later
+      assert(latest)
+      eq("request A", latest.user_prompt)
+    end
+  )
+
+  it(
+    "latest_successful by type returns most recently completed for that type",
+    function()
+      local provider = test_utils.TestProvider.new()
+      _99.setup(test_utils.get_test_setup_options({
+        in_flight_options = { enable = false },
+      }, provider))
+
+      local state = _99.__get_state()
+
+      local prompt_a = Prompt.vibe(state)
+      prompt_a.user_prompt = "vibe A"
+      prompt_a.state = "success"
+      prompt_a.started_at = 100
+      prompt_a.completed_at = 300
+      prompt_a:append_turn("vibe A", "result A")
+      state.tracking:track(prompt_a)
+
+      local prompt_b = Prompt.vibe(state)
+      prompt_b.user_prompt = "vibe B"
+      prompt_b.state = "success"
+      prompt_b.started_at = 200
+      prompt_b.completed_at = 250
+      prompt_b:append_turn("vibe B", "result B")
+      state.tracking:track(prompt_b)
+
+      local prompt_c = Prompt.search(state)
+      prompt_c.user_prompt = "search C"
+      prompt_c.state = "success"
+      prompt_c.started_at = 150
+      prompt_c.completed_at = 400
+      prompt_c:append_turn("search C", "result C")
+      state.tracking:track(prompt_c)
+
+      local latest_vibe = state.tracking:latest_successful("vibe")
+
+      -- Should return A because it completed later
+      assert(latest_vibe)
+      eq("vibe A", latest_vibe.user_prompt)
+    end
+  )
+
+  it(
+    "serialize and reload preserves latest_successful by completion time",
+    function()
+      local previous_counts = vim.deepcopy(Tracking.__config.serialize_count)
+      Tracking.setup({
+        serialize_counts = {
+          vibe = 2,
+          search = 0,
+          tutorial = 0,
+          visual = 0,
+        },
+      })
+
+      local provider = test_utils.TestProvider.new()
+      _99.setup(test_utils.get_test_setup_options({
+        in_flight_options = { enable = false },
+      }, provider))
+
+      local state = _99.__get_state()
+
+      local prompt_a = Prompt.vibe(state)
+      prompt_a.user_prompt = "vibe A"
+      prompt_a.state = "success"
+      prompt_a.started_at = 100
+      prompt_a.completed_at = 200
+      prompt_a:append_turn("vibe A", "result A")
+      state.tracking:track(prompt_a)
+
+      local prompt_b = Prompt.vibe(state)
+      prompt_b.user_prompt = "vibe B"
+      prompt_b.state = "success"
+      prompt_b.started_at = 150
+      prompt_b.completed_at = 300
+      prompt_b:append_turn("vibe B", "result B")
+      state.tracking:track(prompt_b)
+
+      local serialized = state.tracking:serialize()
+
+      -- Create new tracking from serialized data
+      local new_tracking = Tracking.new(state, serialized)
+
+      -- Should return B because it completed later
+      local latest = new_tracking:latest_successful("vibe")
+      assert(latest)
+      eq("vibe B", latest.user_prompt)
+
+      Tracking.__config.serialize_count = previous_counts
+    end
+  )
 end)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Medium risk because it introduces a new continuation flow and changes how prompts are tracked/serialized (sessions, turns, completion timestamps), which affects request history persistence and selection logic across operations.
> 
> **Overview**
> Adds a new `99.continue` API and `ops.continue_chat` operation to continue a previously successful request (optionally the latest and/or filtered by operation), stitching recent conversation turns plus a follow-up prompt into a new request (with special handling for `visual` requiring a fresh selection).
> 
> Extends prompt persistence to support multi-turn sessions by adding `session_id`, `turns`, and `completed_at` timestamps; all successful ops now append turns on completion, and tracking serialization now dedupes by `session_id`, sorts by completion time, and supports explicitly setting serialize counts to `0`.
> 
> Improves robustness in a few related areas: quickfix path parsing now normalizes absolute paths for symlinked temp dirs, providers add a tutorial-only stdout fallback when `TEMP_FILE` is empty, and file scanning removes a `goto`-based skip path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f8a1ebd7ae49f1f08fca5ec5908c73812c837334. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->