### PR TITLE
feat: add pi provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -436,6 +436,7 @@ Referenced content is automatically resolved and injected into the AI context. N
 | `ClaudeCodeProvider` | `claude` | `claude-sonnet-4-5` |
 | `CursorAgentProvider` | `cursor-agent` | `sonnet-4.5` |
 | `GeminiCLIProvider` | `gemini` | `auto` |
+| `PiProvider` | `pi` | `claude-sonnet` |
 
 ```lua
 _99.setup({

--- a/README.md
+++ b/README.md
@@ -435,6 +435,7 @@ Referenced content is automatically resolved and injected into the AI context. N
 | `OpenCodeProvider` (default) | `opencode` | `opencode/claude-sonnet-4-5` |
 | `ClaudeCodeProvider` | `claude` | `claude-sonnet-4-5` |
 | `CursorAgentProvider` | `cursor-agent` | `sonnet-4.5` |
+| `KiroProvider` | `kiro-cli` | `claude-sonnet-4-5` |
 | `GeminiCLIProvider` | `gemini` | `auto` |
 | `PiProvider` | `pi` | `claude-sonnet` |
 

--- a/lua/99/providers.lua
+++ b/lua/99/providers.lua
@@ -329,6 +329,26 @@ function GeminiCLIProvider._get_default_model()
   return "auto"
 end
 
+--- @class PiProvider : _99.Providers.BaseProvider
+local PiProvider = setmetatable({}, { __index = BaseProvider })
+
+--- @param query string
+--- @param context _99.Prompt
+--- @return string[]
+function PiProvider._build_command(_, query, context)
+  return { "pi", "--model", context.model, "--print", query }
+end
+
+--- @return string
+function PiProvider._get_provider_name()
+  return "PiProvider"
+end
+
+--- @return string
+function PiProvider._get_default_model()
+  return "claude-sonnet"
+end
+
 return {
   BaseProvider = BaseProvider,
   OpenCodeProvider = OpenCodeProvider,
@@ -336,4 +356,5 @@ return {
   CursorAgentProvider = CursorAgentProvider,
   KiroProvider = KiroProvider,
   GeminiCLIProvider = GeminiCLIProvider,
+  PiProvider = PiProvider,
 }

--- a/lua/99/test/providers_spec.lua
+++ b/lua/99/test/providers_spec.lua
@@ -87,6 +87,25 @@ describe("providers", function()
     end)
   end)
 
+  describe("PiProvider", function()
+    it("builds correct command with model", function()
+      local request = { model = "claude-sonnet" }
+      local cmd =
+          Providers.PiProvider._build_command(nil, "test query", request)
+      eq({
+        "pi",
+        "--model",
+        "claude-sonnet",
+        "--print",
+        "test query",
+      }, cmd)
+    end)
+
+    it("has correct default model", function()
+      eq("claude-sonnet", Providers.PiProvider._get_default_model())
+    end)
+  end)
+
   describe("provider integration", function()
     it("can be set as provider override", function()
       local _99 = require("99")
@@ -140,6 +159,17 @@ describe("providers", function()
       end
     )
 
+    it(
+      "uses PiProvider default model when provider specified but no model",
+      function()
+        local _99 = require("99")
+
+        _99.setup({ provider = Providers.PiProvider })
+        local state = _99.__get_state()
+        eq("claude-sonnet", state.model)
+      end
+    )
+
     it("uses custom model when both provider and model specified", function()
       local _99 = require("99")
 
@@ -176,6 +206,7 @@ describe("providers", function()
       eq("function", type(Providers.ClaudeCodeProvider.make_request))
       eq("function", type(Providers.CursorAgentProvider.make_request))
       eq("function", type(Providers.GeminiCLIProvider.make_request))
+      eq("function", type(Providers.PiProvider.make_request))
     end)
   end)
 end)


### PR DESCRIPTION
Closes #168 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new optional provider wrapper around the external `pi` CLI and updates docs/tests accordingly, without changing core request execution logic.
> 
> **Overview**
> Adds a new `PiProvider` that routes prompts through the `pi` CLI (`--model … --print`) with a default model of `claude-sonnet`.
> 
> Updates the README provider table to document `PiProvider` (and `KiroProvider`), and adjusts a `Window` test expectation for `scrolloff` when showing the keymap legend popup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 74f053540fcc3b91818413c350937b9da19d43c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->