### PR TITLE
fix(search): Improve reliability of populating quickfix; strengthen permissions for tool calls

### DIFF
--- a/lua/99/prompt-settings.lua
+++ b/lua/99/prompt-settings.lua
@@ -117,9 +117,10 @@ Always use the temporary file as the place to describe your actions according to
   end,
   output_file = function()
     return [[
-NEVER alter any file other than TEMP_FILE.
-never provide the requested changes as conversational output. Return only the code.
-ONLY provide requested changes by writing the change to TEMP_FILE
+NEVER alter any file other than the exact file path inside <TEMP_FILE>.
+You must overwrite that TEMP_FILE path with the final answer using a file-write or file-edit operation.
+Do not print the answer as conversational output or stdout.
+After the write succeeds, stop immediately.
 ]]
   end,
   --- @param prompt string
@@ -181,7 +182,10 @@ local prompt_settings = {
   --- @param tmp_file string
   --- @return string
   tmp_file_location = function(tmp_file)
-    return string.format("<TEMP_FILE>%s</TEMP_FILE>", tmp_file)
+    return string.format(
+      "<TEMP_FILE>%s</TEMP_FILE>",
+      vim.fn.fnamemodify(tmp_file, ":p")
+    )
   end,
 
   --- @return string

--- a/lua/99/prompt.lua
+++ b/lua/99/prompt.lua
@@ -497,15 +497,23 @@ function Prompt:finalize()
       self._99.prompts.get_range_text(visual_data.range)
     )
   end
-  table.insert(
-    self.agent_context,
-    self._99.prompts.tmp_file_location(self.tmp_file)
-  )
+  local provider = self._99.provider_override or BaseProvider.OpenCodeProvider
+  local is_opencode = provider == BaseProvider.OpenCodeProvider
+
+  if not is_opencode then
+    table.insert(
+      self.agent_context,
+      self._99.prompts.tmp_file_location(self.tmp_file)
+    )
+  end
 
   if
-    self.operation == "visual"
-    or self.operation == "tutorial"
-    or self.operation == "search"
+    not is_opencode
+    and (
+      self.operation == "visual"
+      or self.operation == "tutorial"
+      or self.operation == "search"
+    )
   then
     table.insert(self.agent_context, self._99.prompts.only_tmp_file_change())
   end

--- a/lua/99/providers.lua
+++ b/lua/99/providers.lua
@@ -149,6 +149,24 @@ local OpenCodeProvider = setmetatable({}, { __index = BaseProvider })
 --- @param context _99.Prompt
 --- @return string[]
 function OpenCodeProvider._build_command(_, query, context)
+  local prompt_file = context.tmp_file .. "-prompt"
+  local tmp_file = vim.fn.fnamemodify(context.tmp_file, ":p")
+  local title = "99 " .. vim.fn.fnamemodify(context.tmp_file, ":t")
+  local direct_prompt = string.format(
+    [[You are fulfilling a Neovim plugin request.
+
+Read the attached file for the task and context.
+
+Your required final action:
+Write the final result to this file, overwriting it:
+%s
+
+Do not print the final result in chat or stdout.
+Do not modify any other file.
+When the file has been written, stop.]],
+    tmp_file
+  )
+
   return {
     "opencode",
     "run",
@@ -156,7 +174,12 @@ function OpenCodeProvider._build_command(_, query, context)
     "build",
     "-m",
     context.model,
-    query,
+    "--title",
+    title,
+    "--file",
+    prompt_file,
+    "--",
+    direct_prompt,
   }
 end
 

--- a/lua/99/providers.lua
+++ b/lua/99/providers.lua
@@ -19,6 +19,7 @@ end
 
 --- @class _99.Providers.BaseProvider
 --- @field _build_command fun(self: _99.Providers.BaseProvider, query: string, context: _99.Prompt): string[]
+--- @field _build_env? fun(self: _99.Providers.BaseProvider, context: _99.Prompt): table<string, string>
 --- @field _get_provider_name fun(self: _99.Providers.BaseProvider): string
 --- @field _get_default_model fun(): string
 local BaseProvider = {}
@@ -77,37 +78,46 @@ function BaseProvider:make_request(query, context, observer)
   end
   logger:debug("make_request", "command", command)
 
+  local opts = {
+    text = true,
+    stdout = vim.schedule_wrap(function(err, data)
+      logger:debug("stdout", "data", data)
+      if context:is_cancelled() then
+        once_complete("cancelled", "")
+        return
+      end
+      if err and err ~= "" then
+        logger:debug("stdout#error", "err", err)
+      end
+      if not err and data then
+        observer.on_stdout(data)
+      end
+    end),
+    stderr = vim.schedule_wrap(function(err, data)
+      logger:debug("stderr", "data", data)
+      if context:is_cancelled() then
+        once_complete("cancelled", "")
+        return
+      end
+      if err and err ~= "" then
+        logger:debug("stderr#error", "err", err)
+      end
+      if not err then
+        observer.on_stderr(data)
+      end
+    end),
+  }
+
+  if self._build_env then
+    -- OpenCode reads OPENCODE_CONFIG_CONTENT as an inline config overlay.
+    -- Docs: https://opencode.ai/docs/cli/#environment-variables
+    opts.env =
+      vim.tbl_extend("force", vim.fn.environ(), self:_build_env(context))
+  end
+
   local proc = vim.system(
     command,
-    {
-      text = true,
-      stdout = vim.schedule_wrap(function(err, data)
-        logger:debug("stdout", "data", data)
-        if context:is_cancelled() then
-          once_complete("cancelled", "")
-          return
-        end
-        if err and err ~= "" then
-          logger:debug("stdout#error", "err", err)
-        end
-        if not err and data then
-          observer.on_stdout(data)
-        end
-      end),
-      stderr = vim.schedule_wrap(function(err, data)
-        logger:debug("stderr", "data", data)
-        if context:is_cancelled() then
-          once_complete("cancelled", "")
-          return
-        end
-        if err and err ~= "" then
-          logger:debug("stderr#error", "err", err)
-        end
-        if not err then
-          observer.on_stderr(data)
-        end
-      end),
-    },
+    opts,
     vim.schedule_wrap(function(obj)
       if context:is_cancelled() then
         once_complete("cancelled", "")
@@ -145,25 +155,53 @@ end
 --- @class OpenCodeProvider : _99.Providers.BaseProvider
 local OpenCodeProvider = setmetatable({}, { __index = BaseProvider })
 
+--- @param context _99.Prompt
+--- @return table<string, string>
+function OpenCodeProvider._build_env(_, context)
+  local tmp_file = vim.fn.fnamemodify(context.tmp_file, ":p")
+  local relative_tmp_file = context.tmp_file:gsub("^%./", "")
+  -- Permission patterns use wildcards and the last matching rule wins.
+  -- Docs: https://opencode.ai/docs/permissions/#granular-rules-object-syntax
+  local tmp_file_pattern = "*" .. tmp_file .. "*"
+  local relative_tmp_file_pattern = "*" .. relative_tmp_file .. "*"
+  local permissions = {
+    permission = {
+      edit = {
+        ["*"] = "deny",
+        [relative_tmp_file_pattern] = "allow",
+        [tmp_file_pattern] = "allow",
+      },
+      external_directory = {
+        [tmp_file_pattern] = "allow",
+      },
+      bash = "deny",
+      task = "deny",
+    },
+  }
+
+  return {
+    OPENCODE_CONFIG_CONTENT = vim.json.encode(permissions),
+  }
+end
+
 --- @param query string
 --- @param context _99.Prompt
 --- @return string[]
 function OpenCodeProvider._build_command(_, query, context)
-  local prompt_file = context.tmp_file .. "-prompt"
   local tmp_file = vim.fn.fnamemodify(context.tmp_file, ":p")
   local title = "99 " .. vim.fn.fnamemodify(context.tmp_file, ":t")
   local direct_prompt = string.format(
-    [[You are fulfilling a Neovim plugin request.
+    [[You are fulfilling a Neovim plugin request. Follow these instructions directly.
 
-Read the attached file for the task and context.
-
-Your required final action:
-Write the final result to this file, overwriting it:
+Task and output-format instructions:
 %s
 
-Do not print the final result in chat or stdout.
-Do not modify any other file.
-When the file has been written, stop.]],
+Required final action:
+Use the patch or edit tool to overwrite this file with the final result:
+%s
+
+Do not answer in chat or stdout. The result is only complete when the file has been written.]],
+    query,
     tmp_file
   )
 
@@ -176,8 +214,6 @@ When the file has been written, stop.]],
     context.model,
     "--title",
     title,
-    "--file",
-    prompt_file,
     "--",
     direct_prompt,
   }

--- a/lua/99/test/providers_spec.lua
+++ b/lua/99/test/providers_spec.lua
@@ -5,7 +5,10 @@ local Providers = require("99.providers")
 describe("providers", function()
   describe("OpenCodeProvider", function()
     it("builds correct command with model", function()
-      local request = { model = "anthropic/claude-sonnet-4-5" }
+      local request = {
+        model = "anthropic/claude-sonnet-4-5",
+        tmp_file = "./tmp/99-test",
+      }
       local cmd =
         Providers.OpenCodeProvider._build_command(nil, "test query", request)
       eq({
@@ -15,7 +18,22 @@ describe("providers", function()
         "build",
         "-m",
         "anthropic/claude-sonnet-4-5",
-        "test query",
+        "--title",
+        "99 99-test",
+        "--file",
+        "./tmp/99-test-prompt",
+        "--",
+        [[You are fulfilling a Neovim plugin request.
+
+Read the attached file for the task and context.
+
+Your required final action:
+Write the final result to this file, overwriting it:
+]] .. vim.fn.fnamemodify("./tmp/99-test", ":p") .. [[
+
+Do not print the final result in chat or stdout.
+Do not modify any other file.
+When the file has been written, stop.]],
       }, cmd)
     end)
 

--- a/lua/99/test/providers_spec.lua
+++ b/lua/99/test/providers_spec.lua
@@ -20,20 +20,19 @@ describe("providers", function()
         "anthropic/claude-sonnet-4-5",
         "--title",
         "99 99-test",
-        "--file",
-        "./tmp/99-test-prompt",
         "--",
-        [[You are fulfilling a Neovim plugin request.
+        [[You are fulfilling a Neovim plugin request. Follow these instructions directly.
 
-Read the attached file for the task and context.
+Task and output-format instructions:
+test query
 
-Your required final action:
-Write the final result to this file, overwriting it:
-]] .. vim.fn.fnamemodify("./tmp/99-test", ":p") .. [[
+Required final action:
+Use the patch or edit tool to overwrite this file with the final result:
+]]
+          .. vim.fn.fnamemodify("./tmp/99-test", ":p")
+          .. [[
 
-Do not print the final result in chat or stdout.
-Do not modify any other file.
-When the file has been written, stop.]],
+Do not answer in chat or stdout. The result is only complete when the file has been written.]],
       }, cmd)
     end)
 
@@ -42,6 +41,22 @@ When the file has been written, stop.]],
         "opencode/claude-sonnet-4-5",
         Providers.OpenCodeProvider._get_default_model()
       )
+    end)
+
+    it("restricts edits to the response temp file", function()
+      local request = { tmp_file = "./tmp/99-test" }
+      local env = Providers.OpenCodeProvider._build_env(nil, request)
+      local config = vim.json.decode(env.OPENCODE_CONFIG_CONTENT)
+      local tmp_file = vim.fn.fnamemodify("./tmp/99-test", ":p")
+      local tmp_file_pattern = "*" .. tmp_file .. "*"
+      local relative_tmp_file_pattern = "*tmp/99-test*"
+
+      eq("deny", config.permission.edit["*"])
+      eq("allow", config.permission.edit[relative_tmp_file_pattern])
+      eq("allow", config.permission.edit[tmp_file_pattern])
+      eq("allow", config.permission.external_directory[tmp_file_pattern])
+      eq("deny", config.permission.bash)
+      eq("deny", config.permission.task)
     end)
   end)
 


### PR DESCRIPTION
 - Set permissions via opencode config rather than prompt. This should
 be a bit more secure by using a deny-list approach for tool access, granting
 write access only to the output file under `tmp/`.
- Reword prompt to be more general. The XML meta was good for a certain
  era of Claude but isn't broadly applicable: the 'Mandatory' type XML
  tags can get treated as malformed tool data or else prompt injection
  so IMO it hurts the reliability of the feature
- Use opencode's --prompt CLI to read the prompt directly from file. A
  bit more natural with their API
- Hard-code a title so that this is not delegated to agents. Should
  help a bit with cost + latency (see also #166 )

The PR is structured with separate commits in case it's better to apply
only some of the changes.

Address some of the concerns in #135  #175 , hopefully

Tested manually using GPT 5.2 via OpenCode