### PR TITLE
fix: quickfix parser breaks on Windows paths with drive letters

### DIFF
--- a/lua/99/ops/qfix-helpers.lua
+++ b/lua/99/ops/qfix-helpers.lua
@@ -2,7 +2,7 @@ local M = {}
 
 --- @return _99.Search.Result | nil
 function M.parse_line(line)
-  local filepath, lnum_raw, rest = line:match("^(.-):([^:]+):(.+)$")
+  local filepath, lnum_raw, col_raw, _, notes = line:match("^(.-):(%d+):(%d+),([^,]+),?(.*)$")
   if not filepath or not lnum_raw or not rest then
     return nil
   end

--- a/lua/99/ops/qfix-helpers.lua
+++ b/lua/99/ops/qfix-helpers.lua
@@ -7,11 +7,6 @@ function M.parse_line(line)
     return nil
   end
 
-  local col_raw, _, notes = rest:match("^([^,]+),([^,]+),?(.*)$")
-  if not col_raw then
-    return nil
-  end
-
   local lnum = tonumber(lnum_raw) or 1
   local col = tonumber(col_raw) or 1
 

--- a/lua/99/ops/qfix-helpers.lua
+++ b/lua/99/ops/qfix-helpers.lua
@@ -3,7 +3,7 @@ local M = {}
 --- @return _99.Search.Result | nil
 function M.parse_line(line)
   local filepath, lnum_raw, col_raw, _, notes = line:match("^(.-):(%d+):(%d+),([^,]+),?(.*)$")
-  if not filepath or not lnum_raw or not rest then
+  if not filepath or not lnum_raw or not col_raw then
     return nil
   end
 


### PR DESCRIPTION
Fixes #155

The quickfix parser used a greedy `:` split which breaks Windows paths
containing drive letters (e.g. `C:\...`). The `C:` part was mistaken
for the first separator, causing the filepath to be wrong.

Fix: match numeric line/column fields explicitly so the full path is
preserved regardless of OS.