### PR TITLE
fix(providers): CursorAgent deliver prompt via @path to saved file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 tmp
 /.cursor/
+.claude/settings.local.json

--- a/README.md
+++ b/README.md
@@ -437,6 +437,10 @@ Referenced content is automatically resolved and injected into the AI context. N
 | `CursorAgentProvider` | `cursor-agent` | `sonnet-4.5` |
 | `GeminiCLIProvider` | `gemini` | `auto` |
 
+### Cursor Agent
+
+- Prompts are delivered via a single-line `@path` reference to `tmp/99-*-prompt` (written before each request), not as multiline argv to `--print`.
+
 ```lua
 _99.setup({
     provider = _99.Providers.ClaudeCodeProvider,

--- a/lua/99/ops/qfix-helpers.lua
+++ b/lua/99/ops/qfix-helpers.lua
@@ -2,7 +2,7 @@ local M = {}
 
 --- @return _99.Search.Result | nil
 function M.parse_line(line)
-  local filepath, lnum_raw, rest = line:match("^(.-):([^:]+):(.+)$")
+  local filepath, lnum_raw, col_raw, _, notes = line:match("^(.-):(%d+):(%d+),([^,]+),?(.*)$")
   if not filepath or not lnum_raw or not rest then
     return nil
   end

--- a/lua/99/ops/qfix-helpers.lua
+++ b/lua/99/ops/qfix-helpers.lua
@@ -7,11 +7,6 @@ function M.parse_line(line)
     return nil
   end
 
-  local col_raw, _, notes = rest:match("^([^,]+),([^,]+),?(.*)$")
-  if not col_raw then
-    return nil
-  end
-
   local lnum = tonumber(lnum_raw) or 1
   local col = tonumber(col_raw) or 1
 

--- a/lua/99/ops/qfix-helpers.lua
+++ b/lua/99/ops/qfix-helpers.lua
@@ -3,7 +3,7 @@ local M = {}
 --- @return _99.Search.Result | nil
 function M.parse_line(line)
   local filepath, lnum_raw, col_raw, _, notes = line:match("^(.-):(%d+):(%d+),([^,]+),?(.*)$")
-  if not filepath or not lnum_raw or not rest then
+  if not filepath or not lnum_raw or not col_raw then
     return nil
   end
 

--- a/lua/99/providers.lua
+++ b/lua/99/providers.lua
@@ -27,6 +27,23 @@ function BaseProvider.fetch_models(callback)
   callback(nil, "This provider does not support listing models")
 end
 
+--- @return boolean
+function BaseProvider._stdout_as_response()
+  return false
+end
+
+--- @param text string
+--- @return string
+function BaseProvider.strip_markdown_fences(text)
+  local lines = vim.split(text, "\n")
+  if #lines >= 2 and lines[1]:match("^```%w*$") and lines[#lines]:match("^```$") then
+    table.remove(lines, 1)
+    table.remove(lines, #lines)
+    return table.concat(lines, "\n")
+  end
+  return text
+end
+
 --- @param context _99.Prompt
 function BaseProvider:_retrieve_response(context)
   local logger = context.logger:set_area(self:_get_provider_name())
@@ -72,6 +89,9 @@ function BaseProvider:make_request(query, context, observer)
   local command = self:_build_command(query, context)
   logger:debug("make_request", "command", command)
 
+  local stdout_chunks = {}
+  local capture_stdout = self._stdout_as_response()
+
   local proc = vim.system(
     command,
     {
@@ -86,6 +106,9 @@ function BaseProvider:make_request(query, context, observer)
           logger:debug("stdout#error", "err", err)
         end
         if not err and data then
+          if capture_stdout then
+            table.insert(stdout_chunks, data)
+          end
           observer.on_stdout(data)
         end
       end),
@@ -120,6 +143,13 @@ function BaseProvider:make_request(query, context, observer)
         )
       else
         vim.schedule(function()
+          if capture_stdout then
+            local raw = table.concat(stdout_chunks, "")
+            local cleaned = BaseProvider.strip_markdown_fences(vim.trim(raw))
+            if cleaned ~= "" then
+              vim.fn.writefile(vim.split(cleaned, "\n"), context.tmp_file)
+            end
+          end
           local ok, res = self:_retrieve_response(context)
           if ok then
             once_complete("success", res)
@@ -200,6 +230,10 @@ function ClaudeCodeProvider._get_provider_name()
   return "ClaudeCodeProvider"
 end
 
+function ClaudeCodeProvider._stdout_as_response()
+  return true
+end
+
 --- @return string
 function ClaudeCodeProvider._get_default_model()
   return "claude-sonnet-4-5"
@@ -236,6 +270,10 @@ end
 --- @return string
 function CursorAgentProvider._get_provider_name()
   return "CursorAgentProvider"
+end
+
+function CursorAgentProvider._stdout_as_response()
+  return true
 end
 
 --- @return string

--- a/lua/99/providers.lua
+++ b/lua/99/providers.lua
@@ -265,20 +265,41 @@ end
 --- @class CursorAgentProvider : _99.Providers.BaseProvider
 local CursorAgentProvider = setmetatable({}, { __index = BaseProvider })
 
+--- @param context _99.Prompt
+--- @return string
+local function cursor_agent_prompt_file(context)
+  local path = vim.fn.fnamemodify(context.tmp_file .. "-prompt", ":p")
+  path = vim.fs.normalize(path)
+  if vim.fn.filereadable(path) ~= 1 then
+    path = vim.fs.normalize(vim.fn.fnamemodify(
+      vim.fs.joinpath(vim.fn.getcwd(), context.tmp_file .. "-prompt"),
+      ":p"
+    ))
+  end
+  return path
+end
+
+--- @param context _99.Prompt
+--- @return string
+local function cursor_agent_print_prompt(context)
+  return string.format(
+    "Read and follow every instruction in @%s using your file tools, then complete the task exactly as specified in that file.",
+    cursor_agent_prompt_file(context)
+  )
+end
+
 --- @param query string
 --- @param context _99.Prompt
 --- @return string[]
-function CursorAgentProvider._build_command(_, query, context)
-  -- TODO: trust is sort of a hack and should probably be removed in favor of having a
-  -- trust flag from the setup call
+function CursorAgentProvider._build_command(_, _query, context)
   return {
     "cursor-agent",
-    "--trust", -- directories are always trusted and can be ran in
-    "--force", -- allows for commands to run
+    "--trust",
+    "--force",
     "--model",
     context.model,
     "--print",
-    query,
+    cursor_agent_print_prompt(context),
   }
 end
 

--- a/lua/99/test/providers_spec.lua
+++ b/lua/99/test/providers_spec.lua
@@ -48,17 +48,24 @@ describe("providers", function()
   end)
 
   describe("CursorAgentProvider", function()
-    it("builds correct command with model", function()
-      local request = { model = "anthropic/claude-sonnet-4-5" }
-      local cmd =
-        Providers.CursorAgentProvider._build_command(nil, "test query", request)
-      eq({
-        "cursor-agent",
-        "--model",
-        "anthropic/claude-sonnet-4-5",
-        "--print",
-        "test query",
-      }, cmd)
+    it("uses @ prompt file instead of XML on argv", function()
+      local request = { model = "sonnet-4.5", tmp_file = "tmp/99-1234" }
+      local cmd = Providers.CursorAgentProvider._build_command(
+        nil,
+        "<Context>ignored</Context>",
+        request
+      )
+      local print_arg = cmd[#cmd]
+      eq("cursor-agent", cmd[1])
+      eq("--trust", cmd[2])
+      eq("--force", cmd[3])
+      eq("--model", cmd[4])
+      eq("sonnet-4.5", cmd[5])
+      eq("--print", cmd[6])
+      assert(print_arg:match("@"))
+      assert(print_arg:match("99%-1234%-prompt"))
+      assert(not print_arg:match("<Context>"))
+      assert(not print_arg:match("\n"))
     end)
 
     it("has correct default model", function()

--- a/lua/99/test/providers_spec.lua
+++ b/lua/99/test/providers_spec.lua
@@ -160,4 +160,66 @@ describe("providers", function()
       eq("function", type(Providers.GeminiCLIProvider.make_request))
     end)
   end)
+
+  describe("stdout_as_response", function()
+    it("is false for providers that write to temp file", function()
+      eq(false, Providers.OpenCodeProvider._stdout_as_response())
+      eq(false, Providers.KiroProvider._stdout_as_response())
+      eq(false, Providers.GeminiCLIProvider._stdout_as_response())
+    end)
+
+    it("is true for providers using --print flag", function()
+      eq(true, Providers.ClaudeCodeProvider._stdout_as_response())
+      eq(true, Providers.CursorAgentProvider._stdout_as_response())
+    end)
+  end)
+
+  describe("strip_markdown_fences", function()
+    it("strips code fences with language identifier", function()
+      local input = "```python\nis_inventory: bool,\n```"
+      eq(
+        "is_inventory: bool,",
+        Providers.BaseProvider.strip_markdown_fences(input)
+      )
+    end)
+
+    it("strips code fences without language identifier", function()
+      local input = "```\nis_inventory: bool,\n```"
+      eq(
+        "is_inventory: bool,",
+        Providers.BaseProvider.strip_markdown_fences(input)
+      )
+    end)
+
+    it("returns text unchanged when no fences present", function()
+      local input = "is_inventory: bool,"
+      eq(
+        "is_inventory: bool,",
+        Providers.BaseProvider.strip_markdown_fences(input)
+      )
+    end)
+
+    it("handles multi-line content inside fences", function()
+      local input = "```lua\nlocal x = 1\nlocal y = 2\nreturn x + y\n```"
+      eq(
+        "local x = 1\nlocal y = 2\nreturn x + y",
+        Providers.BaseProvider.strip_markdown_fences(input)
+      )
+    end)
+
+    it("handles empty content inside fences", function()
+      local input = "```\n```"
+      eq("", Providers.BaseProvider.strip_markdown_fences(input))
+    end)
+
+    it("trims to empty string for whitespace-only input", function()
+      eq("", vim.trim(Providers.BaseProvider.strip_markdown_fences("\n")))
+      eq("", vim.trim(Providers.BaseProvider.strip_markdown_fences("  \n  ")))
+    end)
+
+    it("does not strip fences that are not wrapping the whole text", function()
+      local input = "some text\n```python\ncode\n```\nmore text"
+      eq(input, Providers.BaseProvider.strip_markdown_fences(input))
+    end)
+  end)
 end)


### PR DESCRIPTION
## Summary

99 saves the full prompt to \	mp/99-*-prompt\ before \make_request\. Stop passing the multiline XML \query\ on argv; pass a single-line \--print\ message with \@absolute/path\ instead.

Same integration pattern as #154 proposes for OpenCode (\--file\).

Closes #180

## Note

Branch is based on \integration/cursor-agent\ which also includes #178 (Windows qfix) and #138 (stdout capture). Those can merge independently first; this PR's CursorAgent change is isolated to prompt delivery.

## Test plan

- [x] Provider spec: print arg is single-line, contains \@\ and \99-*-prompt\, no \<Context>\
- [ ] Manual Windows: search / vibe / visual — agent reads prompt file and runs task
- [ ] Manual Linux: unchanged behavior