### PR TITLE
fix(providers): CursorAgent deliver prompt via @path to saved file

### DIFF
--- a/lua/99/providers.lua
+++ b/lua/99/providers.lua
@@ -231,10 +231,33 @@ end
 --- @class CursorAgentProvider : _99.Providers.BaseProvider
 local CursorAgentProvider = setmetatable({}, { __index = BaseProvider })
 
+--- @param context _99.Prompt
+--- @return string
+local function cursor_agent_prompt_file(context)
+  local path = vim.fn.fnamemodify(context.tmp_file .. "-prompt", ":p")
+  path = vim.fs.normalize(path)
+  if vim.fn.filereadable(path) ~= 1 then
+    path = vim.fs.normalize(vim.fn.fnamemodify(
+      vim.fs.joinpath(vim.fn.getcwd(), context.tmp_file .. "-prompt"),
+      ":p"
+    ))
+  end
+  return path
+end
+
+--- @param context _99.Prompt
+--- @return string
+local function cursor_agent_print_prompt(context)
+  return string.format(
+    "Read and follow every instruction in @%s using your file tools, then complete the task exactly as specified in that file.",
+    cursor_agent_prompt_file(context)
+  )
+end
+
 --- @param query string
 --- @param context _99.Prompt
 --- @return string[]
-function CursorAgentProvider._build_command(_, query, context)
+function CursorAgentProvider._build_command(_, _query, context)
   -- TODO: trust is sort of a hack and should probably be removed in favor of having a
   -- trust flag from the setup call
   return {
@@ -244,7 +267,7 @@ function CursorAgentProvider._build_command(_, query, context)
     "--model",
     context.model,
     "--print",
-    query,
+    cursor_agent_print_prompt(context),
   }
 end
 

--- a/lua/99/providers.lua
+++ b/lua/99/providers.lua
@@ -234,15 +234,20 @@ local CursorAgentProvider = setmetatable({}, { __index = BaseProvider })
 --- @param context _99.Prompt
 --- @return string
 local function cursor_agent_prompt_file(context)
-  local path = vim.fn.fnamemodify(context.tmp_file .. "-prompt", ":p")
-  path = vim.fs.normalize(path)
-  if vim.fn.filereadable(path) ~= 1 then
-    path = vim.fs.normalize(vim.fn.fnamemodify(
-      vim.fs.joinpath(vim.fn.getcwd(), context.tmp_file .. "-prompt"),
+  local rel = context.tmp_file .. "-prompt"
+  local candidates = {
+    vim.fs.normalize(vim.fn.fnamemodify(rel, ":p")),
+    vim.fs.normalize(vim.fn.fnamemodify(
+      vim.fs.joinpath(vim.fn.getcwd(), rel),
       ":p"
-    ))
+    )),
+  }
+  for _, path in ipairs(candidates) do
+    if vim.fn.filereadable(path) == 1 then
+      return path
+    end
   end
-  return path
+  return candidates[1]
 end
 
 --- @param context _99.Prompt

--- a/lua/99/test/providers_spec.lua
+++ b/lua/99/test/providers_spec.lua
@@ -48,17 +48,24 @@ describe("providers", function()
   end)
 
   describe("CursorAgentProvider", function()
-    it("builds correct command with model", function()
-      local request = { model = "anthropic/claude-sonnet-4-5" }
-      local cmd =
-        Providers.CursorAgentProvider._build_command(nil, "test query", request)
-      eq({
-        "cursor-agent",
-        "--model",
-        "anthropic/claude-sonnet-4-5",
-        "--print",
-        "test query",
-      }, cmd)
+    it("uses @ prompt file instead of XML on argv", function()
+      local request = { model = "sonnet-4.5", tmp_file = "tmp/99-1234" }
+      local cmd = Providers.CursorAgentProvider._build_command(
+        nil,
+        "<Context>ignored</Context>",
+        request
+      )
+      local print_arg = cmd[#cmd]
+      eq("cursor-agent", cmd[1])
+      eq("--trust", cmd[2])
+      eq("--force", cmd[3])
+      eq("--model", cmd[4])
+      eq("sonnet-4.5", cmd[5])
+      eq("--print", cmd[6])
+      assert(print_arg:match("@"))
+      assert(print_arg:match("99%-1234%-prompt"))
+      assert(not print_arg:match("<Context>"))
+      assert(not print_arg:match("\n"))
     end)
 
     it("has correct default model", function()

--- a/lua/99/test/providers_spec.lua
+++ b/lua/99/test/providers_spec.lua
@@ -68,6 +68,21 @@ describe("providers", function()
       assert(not print_arg:match("\n"))
     end)
 
+    it("prompt file path prefers a readable candidate", function()
+      local tmp_dir = vim.fn.tempname()
+      vim.fn.mkdir(tmp_dir, "p")
+      local tmp_file = tmp_dir .. "/99-5678"
+      vim.fn.writefile({ "" }, tmp_file .. "-prompt")
+      local cmd = Providers.CursorAgentProvider._build_command(
+        nil,
+        "",
+        { model = "sonnet-4.5", tmp_file = tmp_file }
+      )
+      assert(vim.fn.filereadable(tmp_file .. "-prompt") == 1)
+      assert(cmd[#cmd]:match("99%-5678%-prompt"))
+      vim.fn.delete(tmp_dir, "rf")
+    end)
+
     it("has correct default model", function()
       eq("sonnet-4.5", Providers.CursorAgentProvider._get_default_model())
     end)


### PR DESCRIPTION
## Summary

99 saves the full prompt to `tmp/99-*-prompt` before `make_request`. Stock `CursorAgentProvider` passes the entire multiline XML `query` as the `--print` argv argument, which breaks on Windows when Neovim cwd differs from the project root.

Deliver the prompt via a single-line `--print` message that references the saved file with `@absolute/path` instead.

Same pattern as [#154](https://github.com/ThePrimeagen/99/issues/154) proposes for OpenCode (`--file`).

Closes [#180](https://github.com/ThePrimeagen/99/issues/180)

## Verification

**Windows 11** — search in `C:\Dev\test`. Before fix: multiline `<Context>` on `--print` → agent "Your message looks incomplete". After:

```
{"msg":"saved prompt to file","path":"C:\\Dev\\test\\tmp/99-6155-prompt"}
{"msg":"make_request","command":["cursor-agent","--trust","--force","--model","composer-2.5-fast","--print","Read and follow every instruction in @C:/Dev/test/tmp/99-6155-prompt using your file tools, then complete the task exactly as specified in that file."]}
{"msg":"stdout","data":"Task complete. Results written to `C:/Dev/test/tmp/99-6155`.\n"}
```

**Linux (WSL)** — search, same branch:

```
{"msg":"saved prompt to file","path":"/home/spencerls/tmp/99-9659-prompt"}
{"msg":"make_request","command":["cursor-agent","--trust","--force","--model","composer-2.5-fast","--print","Read and follow every instruction in @/home/spencerls/tmp/99-9659-prompt using your file tools, then complete the task exactly as specified in that file."]}
{"msg":"stdout","data":"Task complete. Results are in `/home/spencerls/tmp/99-9659`.\n"}
```

## Test plan

- [x] Provider spec: print arg is single-line, contains `@` and `99-*-prompt`, no `<Context>`
- [x] Manual Windows: search — agent reads prompt file and runs task
- [x] Manual Linux: search — same behavior
