### PR TITLE
feat: add Agy provider

### DIFF
--- a/lua/99/providers.lua
+++ b/lua/99/providers.lua
@@ -228,6 +228,55 @@ function ClaudeCodeProvider.fetch_models(callback)
   }, nil)
 end
 
+--- @class AgyProvider : _99.Providers.BaseProvider
+local AgyProvider = setmetatable({}, { __index = BaseProvider })
+
+--- @param query string
+--- @param context _99.Prompt
+--- @return string[]
+function AgyProvider._build_command(_, query, context)
+  return {
+    "agy",
+    "--dangerously-skip-permissions",
+    "--model",
+    context.model,
+    "--print",
+    query,
+  }
+end
+
+--- @return string
+function AgyProvider._get_provider_name()
+  return "AgyProvider"
+end
+
+--- @return string
+function AgyProvider._get_default_model()
+  return "gemini-3.5-flash-low"
+end
+
+function AgyProvider.fetch_models(callback)
+  vim.system({ "agy", "models" }, { text = true }, function(obj)
+    vim.schedule(function()
+      if obj.code ~= 0 then
+        callback(nil, "Failed to fetch models from agy")
+        return
+      end
+
+      local models = {}
+      for _, line in ipairs(vim.split(obj.stdout, "\n", { trimempty = true })) do
+        if not line:match("^Fetching available models%.%.%.") then
+          local id = line:match("^(%S+)")
+          if id then
+            table.insert(models, id)
+          end
+        end
+      end
+      callback(models, nil)
+    end)
+  end)
+end
+
 --- @class CursorAgentProvider : _99.Providers.BaseProvider
 local CursorAgentProvider = setmetatable({}, { __index = BaseProvider })
 
@@ -343,6 +392,7 @@ return {
   BaseProvider = BaseProvider,
   OpenCodeProvider = OpenCodeProvider,
   ClaudeCodeProvider = ClaudeCodeProvider,
+  AgyProvider = AgyProvider,
   CursorAgentProvider = CursorAgentProvider,
   KiroProvider = KiroProvider,
   GeminiCLIProvider = GeminiCLIProvider,

--- a/lua/99/test/providers_spec.lua
+++ b/lua/99/test/providers_spec.lua
@@ -47,6 +47,62 @@ describe("providers", function()
     end)
   end)
 
+  describe("AgyProvider", function()
+    it("builds correct command with model", function()
+      local request = { model = "gemini-3.7-flash-low" }
+      local cmd =
+        Providers.AgyProvider._build_command(nil, "test query", request)
+      eq({
+        "agy",
+        "--dangerously-skip-permissions",
+        "--model",
+        "gemini-3.7-flash-low",
+        "--print",
+        "test query",
+      }, cmd)
+    end)
+
+    it("has correct default model", function()
+      eq("gemini-3.5-flash-low", Providers.AgyProvider._get_default_model())
+    end)
+
+    it("parses model ids and ignores status output", function()
+      local original_system = vim.system
+      local original_schedule = vim.schedule
+      local result
+
+      vim.system = function(_, _, callback)
+        callback({
+          code = 0,
+          stdout = table.concat({
+            "Fetching available models...",
+            "gemini-3.5-flash-low Gemini 3.5 Flash (Low)",
+            "gemini-3.5-flash-medium Gemini 3.5 Flash (Medium)",
+            "gemini-3.5-flash-high Gemini 3.5 Flash (High)",
+          }, "\n"),
+        })
+      end
+      vim.schedule = function(fn)
+        fn()
+      end
+
+      Providers.AgyProvider.fetch_models(function(models, err)
+        result = { models = models, err = err }
+      end)
+
+      vim.system = original_system
+      vim.schedule = original_schedule
+      eq({
+        models = {
+          "gemini-3.5-flash-low",
+          "gemini-3.5-flash-medium",
+          "gemini-3.5-flash-high",
+        },
+        err = nil,
+      }, result)
+    end)
+  end)
+
   describe("CursorAgentProvider", function()
     it("builds correct command with model", function()
       local request = { model = "anthropic/claude-sonnet-4-5" }
@@ -140,6 +196,17 @@ describe("providers", function()
       end
     )
 
+    it(
+      "uses AgyProvider default model when provider specified but no model",
+      function()
+        local _99 = require("99")
+
+        _99.setup({ provider = Providers.AgyProvider })
+        local state = _99.__get_state()
+        eq("gemini-3.5-flash-low", state.model)
+      end
+    )
+
     it("uses custom model when both provider and model specified", function()
       local _99 = require("99")
 
@@ -176,6 +243,7 @@ describe("providers", function()
       eq("function", type(Providers.ClaudeCodeProvider.make_request))
       eq("function", type(Providers.CursorAgentProvider.make_request))
       eq("function", type(Providers.GeminiCLIProvider.make_request))
+      eq("function", type(Providers.AgyProvider.make_request))
     end)
   end)
 end)


### PR DESCRIPTION
## Summary

Adds an `AgyProvider` for the Antigravity `agy` CLI.

- Uses `agy --dangerously-skip-permissions --model <model> --print <prompt>`
- Defaults to `gemini-3.5-flash-low`
- Discovers models through `agy models`
- Parses model IDs while ignoring `Fetching available models...`
- Reuses 99's existing temporary-file prompt contract; no provider-specific file I/O was added

## Tests

- Provider command construction: pass
- Default model and provider registration: pass
- Model parsing: pass
- Manual Agy file-output smoke test: pass; exit code 0 and response written to the requested temporary file
- `make lua_test`: Agy tests pass; the existing suite also reports unrelated failures in CursorAgentProvider expectations and macOS `/tmp` path normalization

The provider is opt-in and does not change the default provider.